### PR TITLE
Build kotlin gradle dsl projects

### DIFF
--- a/fabric-chaincode-docker/build.sh
+++ b/fabric-chaincode-docker/build.sh
@@ -70,7 +70,7 @@ else
 fi
 
 
-if [ -f "/chaincode/input/src/build.gradle" ]
+if [ -f "/chaincode/input/src/build.gradle" ] || [ -f "/chaincode/input/src/build.gradle.kts" ]
 then
     buildGradle /chaincode/input/src/ /chaincode/output/
 else


### PR DESCRIPTION
Add a check for `build.gradle.kts` file in the project root dir to prevent it from building through maven

[https://jira.hyperledger.org/browse/FAB-14292](https://jira.hyperledger.org/browse/FAB-14292)
