### PR TITLE
[FAB-15634] Annotations for Serializer

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/annotation/Contract.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/annotation/Contract.java
@@ -38,4 +38,15 @@ public @interface Contract {
      * @return Name of the contract to be used instead of the Classname
      */
     String name() default "";
+
+    /**
+     * Fully Qualified Classname of the TRANSACTION serializer 
+     * that should be used with this contract.
+     * 
+     * This is the serializer that is used to parse incoming transaction request
+     * parameters and convert the return type
+     */
+    String transactionSerializer() default "org.hyperledger.fabric.contract.execution.JSONTransactionSerializer";
+
+
 }

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/annotation/Serializer.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/annotation/Serializer.java
@@ -1,0 +1,28 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.hyperledger.fabric.contract.annotation;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Class level annotation that defines the serializer that should be used to
+ * convert objects to and from the wire format.
+ * 
+ * This should annotate a class that implements the Serializer interface
+ */
+@Retention(RUNTIME)
+@Target({ElementType.TYPE,ElementType.TYPE_USE})
+public @interface Serializer {
+    public enum TARGET {
+        TRANSACTION, ALL
+    }
+
+    TARGET target() default Serializer.TARGET.ALL; 
+}

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/annotation/Transaction.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/annotation/Transaction.java
@@ -23,6 +23,14 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Target(METHOD)
 public @interface Transaction {
+
+    /**
+     * SUBMIT or EVALUATE semantics
+     */
+    public enum TYPE {
+        SUBMIT,EVALUATE
+    }
+
     /**
      * TRUE indicates that this function is intended to be called with the 'submit'
      * semantics
@@ -31,8 +39,16 @@ public @interface Transaction {
      * semantics
      *
      * @return boolean, default is true
+     * @deprecated Please use intent
      */
+    @Deprecated
     boolean submit() default true;
+
+    /**
+     * SUBMIT - indicates that this function is intended to be called with the 'submit' semantics
+     * EVALUATE - indicates that this is intended to be called with the 'evaluate' semantics
+     */
+    TYPE intent() default Transaction.TYPE.SUBMIT;
 
     /**
      * The name of the callable transaction if it should be different to the method

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/ExecutionFactory.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/ExecutionFactory.java
@@ -8,7 +8,6 @@ package org.hyperledger.fabric.contract.execution;
 
 import org.hyperledger.fabric.contract.execution.impl.ContractExecutionService;
 import org.hyperledger.fabric.contract.execution.impl.ContractInvocationRequest;
-import org.hyperledger.fabric.contract.routing.TypeRegistry;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
 public class ExecutionFactory {
@@ -26,9 +25,10 @@ public class ExecutionFactory {
         return new ContractInvocationRequest(context);
     }
 
-    public ExecutionService createExecutionService(TypeRegistry typeRegistry) {
+
+    public ExecutionService createExecutionService(SerializerInterface serializers) {
         if (es == null) {
-            es = new ContractExecutionService(typeRegistry);
+            es = new ContractExecutionService(serializers);
         }
         return es;
     }

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializer.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializer.java
@@ -25,20 +25,20 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import org.hyperledger.fabric.contract.annotation.Serializer;
+
 /**
  * Used as a the default serialisation for transmission from SDK to Contract
  */
-public class JSONTransactionSerializer {
+@Serializer() 
+public class JSONTransactionSerializer implements SerializerInterface {
     private static Logger logger = Logger.getLogger(JSONTransactionSerializer.class.getName());
-    private TypeRegistry typeRegistry;
+    private TypeRegistry typeRegistry = TypeRegistry.getRegistry();
 
     /**
-     * Create a new serialiser and maintain a reference to the TypeRegistry
-     *
-     * @param typeRegistry
+     * Create a new serialiser
      */
-    public JSONTransactionSerializer(TypeRegistry typeRegistry) {
-        this.typeRegistry = typeRegistry;
+    public JSONTransactionSerializer() {
     }
 
     /**
@@ -48,6 +48,7 @@ public class JSONTransactionSerializer {
      * @param ts
      * @return  Byte buffer
      */
+    @Override
     public byte[] toBuffer(Object value, TypeSchema ts) {
         logger.debug(() -> "Schema to convert is " + ts);
         byte[] buffer = null;
@@ -87,6 +88,7 @@ public class JSONTransactionSerializer {
      * @throws InstantiationException
      * @throws IllegalAccessException
      */
+    @Override
     public Object fromBuffer(byte[] buffer, TypeSchema ts) {
         try {
             String stringData = new String(buffer, StandardCharsets.UTF_8);

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/SerializerInterface.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/SerializerInterface.java
@@ -1,0 +1,45 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package org.hyperledger.fabric.contract.execution;
+
+import org.hyperledger.fabric.contract.metadata.TypeSchema;
+import org.hyperledger.fabric.contract.routing.TypeRegistry;
+
+/**
+ * This interface allows contract developers to change the serialization mechanism.
+ * There are two scenaios where instances of DataTypes are serialized. 
+ * 
+ * When the objects are (logically) transferred from the Client application to the Contract resulting
+ * in a transaction function being invoked. Typicaly this is JSON, hence a default JSON parser is provided.
+ * 
+ * The JSONTransactionSerializer can be extended if needed
+ */
+public interface SerializerInterface {
+
+    /**
+     * Convert the value supplied to a byte array, according to the TypeSchema
+     *
+     * @param value
+     * @param ts
+     * @return
+     */
+    byte[] toBuffer(Object value, TypeSchema ts);
+
+    /**
+     * Take the byte buffer and return the object as required
+     *
+     * @param buffer Byte buffer from the wire
+     * @param ts     TypeSchema representing the type
+     *
+     * @return Object created; relies on Java auto-boxing for primitives
+     *
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    Object fromBuffer(byte[] buffer, TypeSchema ts);
+
+}

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
@@ -18,11 +18,10 @@ import org.hyperledger.fabric.contract.ContractInterface;
 import org.hyperledger.fabric.contract.ContractRuntimeException;
 import org.hyperledger.fabric.contract.execution.ExecutionService;
 import org.hyperledger.fabric.contract.execution.InvocationRequest;
-import org.hyperledger.fabric.contract.execution.JSONTransactionSerializer;
+import org.hyperledger.fabric.contract.execution.SerializerInterface;
 import org.hyperledger.fabric.contract.metadata.TypeSchema;
 import org.hyperledger.fabric.contract.routing.ParameterDefinition;
 import org.hyperledger.fabric.contract.routing.TxFunction;
-import org.hyperledger.fabric.contract.routing.TypeRegistry;
 import org.hyperledger.fabric.shim.Chaincode;
 import org.hyperledger.fabric.shim.ChaincodeException;
 import org.hyperledger.fabric.shim.ChaincodeStub;
@@ -32,12 +31,11 @@ public class ContractExecutionService implements ExecutionService {
 
     private static Logger logger = Logger.getLogger(ContractExecutionService.class.getName());
 
-    private JSONTransactionSerializer serializer;
+    private SerializerInterface serializer;
     Map<String, Object> proxies = new HashMap<>();
 
-    public ContractExecutionService(TypeRegistry typeRegistry) {
-        // FUTURE: Permit this to swapped out as per node.js
-        this.serializer = new JSONTransactionSerializer(typeRegistry);
+    public ContractExecutionService(SerializerInterface serializer) {
+        this.serializer = serializer;
     }
 
     @Override

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/TxFunction.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/TxFunction.java
@@ -22,6 +22,7 @@ public interface TxFunction {
 
         ContractInterface getContractInstance() throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException;
 
+        String getSerializerName();
     }
 
     boolean isUnknownTx();
@@ -45,4 +46,6 @@ public interface TxFunction {
     void setParameterDefinitions(List<ParameterDefinition> list);
 
     List<ParameterDefinition> getParamsList();
+
+  
 }

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/TypeRegistry.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/TypeRegistry.java
@@ -7,7 +7,13 @@ package org.hyperledger.fabric.contract.routing;
 
 import java.util.Collection;
 
+import org.hyperledger.fabric.contract.routing.impl.TypeRegistryImpl;
+
 public interface TypeRegistry {
+
+	static TypeRegistry getRegistry(){
+		return TypeRegistryImpl.getInstance();
+	}
 
 	void addDataType(DataTypeDefinition dtd);
 

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/DataTypeDefinitionImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/DataTypeDefinitionImpl.java
@@ -6,9 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package org.hyperledger.fabric.contract.routing.impl;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/SerializerRegistryImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/SerializerRegistryImpl.java
@@ -1,0 +1,108 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.hyperledger.fabric.contract.routing.impl;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hyperledger.fabric.Logger;
+import org.hyperledger.fabric.contract.annotation.Serializer;
+import org.hyperledger.fabric.contract.execution.SerializerInterface;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+
+/**
+ * Registry to hold permit access to the serializer implementations. 
+ * 
+ * It holds the serializers that have been defined. JSONTransacationSerializer is the 
+ * default.
+ */
+public class SerializerRegistryImpl {
+    private static Logger logger = Logger.getLogger(SerializerRegistryImpl.class);
+
+    private Class<Serializer> annotationClass = Serializer.class;
+
+    public SerializerRegistryImpl() {
+    }
+
+    // Could index these by name and or type.
+    private Map<String, SerializerInterface> contents = new HashMap<>();
+
+    /**
+     * Get a Serializer for the matching fully qualified classname, and the Target
+     * 
+     * @param name    fully qualified classname
+     * @param target  the intended target of the serializer
+     */
+    public SerializerInterface getSerializer(String name, Serializer.TARGET target) {
+        String key = name+":"+target;
+        System.out.println("Getting "+key);
+        return contents.get(key);
+    }
+
+    private SerializerInterface add(String name, Serializer.TARGET target, Class<SerializerInterface> clazz) {
+        logger.debug(() -> "Adding new Class " + clazz.getCanonicalName()+" for "+target);
+        try{
+        	String key = name+":"+target;
+            SerializerInterface newObj = clazz.newInstance();
+            System.out.println("Addding "+key);
+            this.contents.put(key,newObj);
+
+            return newObj;
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Find all the serializers that have been defined
+     * 
+     * @see
+     * org.hyperledger.fabric.contract.routing.RoutingRegistry#findAndSetContracts()
+     */
+    public void findAndSetContents() throws InstantiationException, IllegalAccessException {
+
+        ClassGraph classGraph = new ClassGraph()
+            .enableClassInfo()
+            .enableAnnotationInfo();
+
+        // set to ensure that we don't scan the same class twice
+        Set<String> seenClass = new HashSet<>();
+
+        try (ScanResult scanResult = classGraph.scan()) {
+            for (ClassInfo classInfo : scanResult.getClassesWithAnnotation(this.annotationClass.getCanonicalName())) {
+                logger.debug("Found class with contract annotation: " + classInfo.getName());
+                try {
+                    Class<SerializerInterface> cls = (Class<SerializerInterface>)classInfo.loadClass();
+                    logger.debug("Loaded class");
+
+                    String className = cls.getCanonicalName();
+                    if (!seenClass.contains(className)) {
+                        seenClass.add(className);
+                        this.add(className, Serializer.TARGET.TRANSACTION, cls);
+                    }
+                    
+                } catch (IllegalArgumentException e) {
+                    logger.debug("Failed to load class: " + e);
+                }
+            }
+
+        }
+
+    }
+
+
+}

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TxFunctionImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TxFunctionImpl.java
@@ -38,10 +38,12 @@ public class TxFunctionImpl implements TxFunction {
 
         Method method;
         Class<? extends ContractInterface> clazz;
+        String serializerName;
 
-        public RoutingImpl(Method method, Class<? extends ContractInterface> clazz) {
+        public RoutingImpl(Method method, ContractDefinition contract) {
             this.method = method;
-            this.clazz = clazz;
+            this.clazz =  contract.getContractImpl();
+            this.serializerName = contract.getAnnotation().transactionSerializer();
         }
 
         @Override
@@ -63,6 +65,12 @@ public class TxFunctionImpl implements TxFunction {
         public String toString() {
             return method.getName() + ":" + clazz.getCanonicalName();
         }
+
+        @Override
+        public String getSerializerName() {
+           return serializerName;
+        }
+
     }
 
     /**
@@ -92,8 +100,10 @@ public class TxFunctionImpl implements TxFunction {
             this.name = m.getName();
         }
 
-        this.routing = new RoutingImpl(m, contract.getContractImpl());
-
+        // create the routing object that defines how to get the data to the transaction 
+        // function.
+        this.routing = new RoutingImpl(m,contract);
+       
         // set the return schema
         this.returnSchema = TypeSchema.typeConvert(m.getReturnType());
 

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TypeRegistryImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TypeRegistryImpl.java
@@ -20,6 +20,17 @@ import org.hyperledger.fabric.contract.routing.TypeRegistry;
  */
 public class TypeRegistryImpl implements TypeRegistry {
 
+
+	private static TypeRegistryImpl singletonInstance;
+
+	public static TypeRegistry getInstance(){
+		if (singletonInstance == null){
+			singletonInstance = new TypeRegistryImpl();
+		}
+
+		return singletonInstance;
+	}
+
 	private Map<String, DataTypeDefinition> components = new HashMap<>();
 
 	/* (non-Javadoc)

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/ContractExecutionServiceTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/ContractExecutionServiceTest.java
@@ -41,9 +41,10 @@ public class ContractExecutionServiceTest {
     @Test
     public void noReturnValue()
             throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException, SecurityException {
-        TypeRegistry typeRegistry = new TypeRegistryImpl();
 
-        ContractExecutionService ces = new ContractExecutionService(typeRegistry);
+        JSONTransactionSerializer jts = new JSONTransactionSerializer();
+        
+        ContractExecutionService ces = new ContractExecutionService(jts);
 
         ContractInterface contract = spy(new SampleContract());
         TxFunction txFn = mock(TxFunction.class);
@@ -66,9 +67,9 @@ public class ContractExecutionServiceTest {
     @Test()
     public void failureToInvoke()
             throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException, SecurityException {
-        TypeRegistry typeRegistry = new TypeRegistryImpl();
 
-        ContractExecutionService ces = new ContractExecutionService(typeRegistry);
+        JSONTransactionSerializer jts = new JSONTransactionSerializer();
+        ContractExecutionService ces = new ContractExecutionService(jts);
 
         spy(new SampleContract());
         TxFunction txFn = mock(TxFunction.class);

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializerTest.java
@@ -26,8 +26,8 @@ public class JSONTransactionSerializerTest {
 
 	@Test
 	public void toBuffer() {
-		TypeRegistry tr = new TypeRegistryImpl();
-		JSONTransactionSerializer serializer = new JSONTransactionSerializer(tr);
+		
+		JSONTransactionSerializer serializer = new JSONTransactionSerializer();
 
 		byte[] bytes = serializer.toBuffer("hello world", TypeSchema.typeConvert(String.class));
 		assertThat(new String(bytes, StandardCharsets.UTF_8), equalTo("hello world"));
@@ -65,7 +65,8 @@ public class JSONTransactionSerializerTest {
 
 		MetadataBuilder.addComponent(tr.getDataType("MyType"));
 
-		JSONTransactionSerializer serializer = new JSONTransactionSerializer(tr);
+		JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+		
 		TypeSchema ts = TypeSchema.typeConvert(MyType[].class);
 		MyType[] o = (MyType[]) serializer.fromBuffer(buffer, ts);
 		assertThat(o[0].toString(),equalTo("++++ MyType: hello"));
@@ -76,7 +77,8 @@ public class JSONTransactionSerializerTest {
 	@Test
 	public void toBufferPrimitive() {
 		TypeRegistry tr = new TypeRegistryImpl();
-		JSONTransactionSerializer serializer = new JSONTransactionSerializer(tr);
+		JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+		
 
 		TypeSchema ts;
 		Object value;
@@ -118,7 +120,8 @@ public class JSONTransactionSerializerTest {
 		TypeRegistry tr = new TypeRegistryImpl();
 		tr.addDataType(MyType.class);
 		MetadataBuilder.addComponent(tr.getDataType("MyType"));
-		JSONTransactionSerializer serializer = new JSONTransactionSerializer(tr);
+		JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+		
 		TypeSchema ts = TypeSchema.typeConvert(MyType[].class);
 		serializer.toBuffer(null, ts);
 	}

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/TxFunctionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/TxFunctionTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.ContractInterface;
 import org.hyperledger.fabric.contract.ContractRuntimeException;
+import org.hyperledger.fabric.contract.annotation.Contract;
 import org.hyperledger.fabric.contract.annotation.Property;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 import org.hyperledger.fabric.contract.metadata.TypeSchema;
@@ -23,11 +24,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 public class TxFunctionTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    @Contract()
     class TestObject implements ContractInterface {
 
         @Transaction()
@@ -54,6 +57,7 @@ public class TxFunctionTest {
     public void constructor() throws NoSuchMethodException, SecurityException {
         TestObject test = new TestObject();
         ContractDefinition cd = mock(ContractDefinition.class);
+        Mockito.when(cd.getAnnotation()).thenReturn(test.getClass().getAnnotation(Contract.class));
 
         TxFunction txfn = new TxFunctionImpl(test.getClass().getMethod("testMethod1", new Class<?>[] { Context.class }),
                 cd);
@@ -67,7 +71,7 @@ public class TxFunctionTest {
     public void property() throws NoSuchMethodException, SecurityException {
         TestObject test = new TestObject();
         ContractDefinition cd = mock(ContractDefinition.class);
-
+        Mockito.when(cd.getAnnotation()).thenReturn(test.getClass().getAnnotation(Contract.class));
         TxFunction txfn = new TxFunctionImpl(
                 test.getClass().getMethod("testMethod2", new Class<?>[] { Context.class, int.class }), cd);
         String name = txfn.getName();
@@ -90,7 +94,7 @@ public class TxFunctionTest {
     public void invaldtxfn() throws NoSuchMethodException, SecurityException {
         TestObject test = new TestObject();
         ContractDefinition cd = mock(ContractDefinition.class);
-
+        Mockito.when(cd.getAnnotation()).thenReturn(test.getClass().getAnnotation(Contract.class));
         thrown.expect(ContractRuntimeException.class);
         new TxFunctionImpl(test.getClass().getMethod("wibble", new Class[] { String.class }), cd);
 


### PR DESCRIPTION
Provides the annotation to say what serializer is in use.
Defaults to the current JSON format.

Users can implement their own if they wish.

This brings Java up to the same functional level as Node.

Signed-off-by: Matthew B. White <whitemat@uk.ibm.com>