### PR TITLE
[FABCJ-183] Extra properties appear in JSON from Java Objects

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
@@ -50,7 +50,7 @@ public class ContractExecutionService implements ExecutionService {
 
             final List<Object> args = convertArgs(req.getArgs(), txFn);
             args.add(0, context); // force context into 1st position, other elements move up
-
+            
             contractObject.beforeTransaction(context);
             Object value = rd.getMethod().invoke(contractObject, args.toArray());
             contractObject.afterTransaction(context, value);

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/metadata/TypeSchema.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/metadata/TypeSchema.java
@@ -100,7 +100,37 @@ public class TypeSchema extends HashMap<String, Object> {
         if (type.contentEquals("string")) {
             clz = String.class;
         } else if (type.contentEquals("integer")) {
-            clz = int.class;
+            // need to check the format
+            String format = getFormat();
+            switch(format) {
+                case "int8":
+                  clz = byte.class;
+                  break;
+                case "int16":
+                  clz = short.class;
+                  break;
+                case "int32":
+                  clz = int.class;
+                  break;
+                case "int64":
+                  clz = long.class;
+                  break;
+                default:
+                  throw new RuntimeException("Unkown format for integer of "+format);
+            }
+        } else if (type.contentEquals("number")) {
+            // need to check the format
+            String format = getFormat();
+            switch(format) {
+                case "double":
+                  clz = double.class;
+                  break;
+                case "float":
+                  clz = float.class;
+                  break;
+                default:
+                  throw new RuntimeException("Unkown format for number of "+format);
+            }
         } else if (type.contentEquals("boolean")) {
             clz = boolean.class;
         } else if (type.contentEquals("object")) {
@@ -132,8 +162,17 @@ public class TypeSchema extends HashMap<String, Object> {
         if (clz.isArray()) {
             returnschema.put("type", "array");
             schema = new TypeSchema();
-            returnschema.put("items", schema);
-            className = className.substring(0, className.length() - 2);
+            
+            // double check the componentType
+            Class<?> componentClass = clz.getComponentType();
+            if (componentClass.isArray()){
+                // nested arrays
+                returnschema.put("items",TypeSchema.typeConvert(componentClass));
+            } else {
+                returnschema.put("items", schema);
+            }
+            
+            className = componentClass.getTypeName();
         } else {
             schema = returnschema;
         }
@@ -177,7 +216,6 @@ public class TypeSchema extends HashMap<String, Object> {
             schema.put("type", "boolean");
             break;
         default:
-
             schema.put("$ref", "#/components/schemas/" + className.substring(className.lastIndexOf('.') + 1));
         }
 

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/DataTypeDefinition.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/DataTypeDefinition.java
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package org.hyperledger.fabric.contract.routing;
 
 import java.util.Map;
+import org.hyperledger.fabric.contract.metadata.TypeSchema;
 
 public interface DataTypeDefinition {
 
@@ -15,5 +16,7 @@ public interface DataTypeDefinition {
 
 	String getSimpleName();
 
-    Class<?> getTypeClass();
+	Class<?> getTypeClass();
+	
+	TypeSchema getSchema();
 }

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/TypeRegistry.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/TypeRegistry.java
@@ -6,8 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package org.hyperledger.fabric.contract.routing;
 
 import java.util.Collection;
-
 import org.hyperledger.fabric.contract.routing.impl.TypeRegistryImpl;
+import org.hyperledger.fabric.contract.metadata.TypeSchema;
 
 public interface TypeRegistry {
 
@@ -20,6 +20,8 @@ public interface TypeRegistry {
 	void addDataType(Class<?> cl);
 
 	DataTypeDefinition getDataType(String name);
+
+	DataTypeDefinition getDataType(TypeSchema schema);
 
 	Collection<DataTypeDefinition> getAllDataTypes();
 

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/DataTypeDefinitionImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/DataTypeDefinitionImpl.java
@@ -70,6 +70,10 @@ public class DataTypeDefinitionImpl implements DataTypeDefinition {
 		return this.clazz;
 	}
 
+	public TypeSchema getSchema() {
+		return TypeSchema.typeConvert(this.clazz);
+	}
+
 	/*
 	 * (non-Javadoc)
 	 *
@@ -100,6 +104,11 @@ public class DataTypeDefinitionImpl implements DataTypeDefinition {
 	@Override
 	public String getSimpleName() {
 		return simpleName;
+	}
+
+	@Override
+	public String toString() {
+		return this.simpleName + " " + properties;
 	}
 
 }

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/SerializerRegistryImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/SerializerRegistryImpl.java
@@ -49,7 +49,6 @@ public class SerializerRegistryImpl {
      */
     public SerializerInterface getSerializer(String name, Serializer.TARGET target) {
         String key = name+":"+target;
-        System.out.println("Getting "+key);
         return contents.get(key);
     }
 
@@ -58,7 +57,6 @@ public class SerializerRegistryImpl {
         try{
         	String key = name+":"+target;
             SerializerInterface newObj = clazz.newInstance();
-            System.out.println("Addding "+key);
             this.contents.put(key,newObj);
 
             return newObj;

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TypeRegistryImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TypeRegistryImpl.java
@@ -9,7 +9,7 @@ package org.hyperledger.fabric.contract.routing.impl;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
+import org.hyperledger.fabric.contract.metadata.TypeSchema;
 import org.hyperledger.fabric.contract.routing.DataTypeDefinition;
 import org.hyperledger.fabric.contract.routing.TypeRegistry;
 
@@ -19,7 +19,6 @@ import org.hyperledger.fabric.contract.routing.TypeRegistry;
  *
  */
 public class TypeRegistryImpl implements TypeRegistry {
-
 
 	private static TypeRegistryImpl singletonInstance;
 
@@ -58,6 +57,13 @@ public class TypeRegistryImpl implements TypeRegistry {
 	@Override
 	public DataTypeDefinition getDataType(String name) {
 		return this.components.get(name);
+	}
+
+	@Override
+	public DataTypeDefinition getDataType(TypeSchema schema) {
+		String ref = schema.getRef();
+		String format = ref.substring(ref.lastIndexOf("/") + 1);
+		return getDataType(format);
 	}
 
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/MyType.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/MyType.java
@@ -15,6 +15,23 @@ public class MyType {
 	@Property()
 	private String value;
 
+	private String state="";
+
+	public final static String STARTED = "STARTED";
+	public final static String STOPPED = "STOPPED";
+
+	public void setState(String state){
+		this.state = state;
+	}
+
+	public boolean isStarted(){
+		return state.equals(STARTED);
+	}
+
+	public boolean isStopped(){
+		return state.equals(STARTED);
+	}
+
 	public MyType setValue(String value) {
 		this.value = value;
 		return this;

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializerTest.java
@@ -17,8 +17,11 @@ import org.hyperledger.fabric.contract.metadata.TypeSchema;
 import org.hyperledger.fabric.contract.routing.TypeRegistry;
 import org.hyperledger.fabric.contract.routing.impl.TypeRegistryImpl;
 import org.junit.Rule;
-import org.junit.Test;
+
 import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 public class JSONTransactionSerializerTest {
 	@Rule
@@ -26,7 +29,11 @@ public class JSONTransactionSerializerTest {
 
 	@Test
 	public void toBuffer() {
+		TypeRegistry tr = TypeRegistry.getRegistry();
 		
+		tr.addDataType(MyType.class);
+
+		MetadataBuilder.addComponent(tr.getDataType("MyType"));
 		JSONTransactionSerializer serializer = new JSONTransactionSerializer();
 
 		byte[] bytes = serializer.toBuffer("hello world", TypeSchema.typeConvert(String.class));
@@ -56,11 +63,103 @@ public class JSONTransactionSerializerTest {
 		assertThat(bytes, equalTo(buffer));
 	}
 
+	@Nested
+	@DisplayName("Primitive Arrays")
+	class PrimitiveArrays{
+		@Test
+		public void ints(){
+			JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+			// convert array of primitive
+			int[] intarray = new int[]{42,83};
+			byte[] bytes = serializer.toBuffer(intarray, TypeSchema.typeConvert(int[].class));
+			assertThat(new String(bytes,StandardCharsets.UTF_8),equalTo("[42,83]"));
+
+			Object returned = serializer.fromBuffer(bytes,TypeSchema.typeConvert(int[].class));
+			assertThat(returned,equalTo(intarray));
+		}
+
+		@Test
+		public void bytes(){
+			JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+			// convert array of primitive
+			byte[] array = new byte[]{42,83};
+			byte[] bytes = serializer.toBuffer(array, TypeSchema.typeConvert(byte[].class));
+			assertThat(new String(bytes,StandardCharsets.UTF_8),equalTo("[42,83]"));
+
+			Object returned = serializer.fromBuffer(bytes,TypeSchema.typeConvert(byte[].class));
+			assertThat(returned,equalTo(array));
+		}
+
+	}
+
+
+
+
+    @Nested
+    @DisplayName("Nested Arrays")
+    class NestedArrays {
+		@Test
+		public void ints(){
+			JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+			int[][] array = new int[][]{{42,83},{83,42}};
+			byte[] bytes = serializer.toBuffer(array, TypeSchema.typeConvert(int[][].class));
+			assertThat(new String(bytes,StandardCharsets.UTF_8),equalTo("[[42,83],[83,42]]"));
+	
+			Object returned = serializer.fromBuffer(bytes,TypeSchema.typeConvert(int[][].class));
+			assertThat(returned,equalTo(array));
+		}
+
+		@Test
+		public void longs(){
+			JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+			long[][] array = new long[][]{{42L,83L},{83L,42L}};
+			byte[] bytes = serializer.toBuffer(array, TypeSchema.typeConvert(long[][].class));
+			assertThat(new String(bytes,StandardCharsets.UTF_8),equalTo("[[42,83],[83,42]]"));
+	
+			Object returned = serializer.fromBuffer(bytes,TypeSchema.typeConvert(long[][].class));
+			assertThat(returned,equalTo(array));
+		}
+
+		@Test
+		public void doubles(){
+			JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+			double[][] array = new double[][]{{42.42d,83.83d},{83.23d,42.33d}};
+			byte[] bytes = serializer.toBuffer(array, TypeSchema.typeConvert(double[][].class));
+			assertThat(new String(bytes,StandardCharsets.UTF_8),equalTo("[[42.42,83.83],[83.23,42.33]]"));
+	
+			Object returned = serializer.fromBuffer(bytes,TypeSchema.typeConvert(double[][].class));
+			assertThat(returned,equalTo(array));
+		}
+
+		@Test
+		public void bytes(){
+			JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+			byte[][] array = new byte[][]{{42,83},{83,42}};
+			byte[] bytes = serializer.toBuffer(array, TypeSchema.typeConvert(byte[][].class));
+			assertThat(new String(bytes,StandardCharsets.UTF_8),equalTo("[[42,83],[83,42]]"));
+	
+			Object returned = serializer.fromBuffer(bytes,TypeSchema.typeConvert(byte[][].class));
+			assertThat(returned,equalTo(array));
+		}
+		@Test
+		public void shorts(){
+			JSONTransactionSerializer serializer = new JSONTransactionSerializer();
+			short[][] array = new short[][]{{42,83},{83,42}};
+			byte[] bytes = serializer.toBuffer(array, TypeSchema.typeConvert(short[][].class));
+			assertThat(new String(bytes,StandardCharsets.UTF_8),equalTo("[[42,83],[83,42]]"));
+	
+			Object returned = serializer.fromBuffer(bytes,TypeSchema.typeConvert(short[][].class));
+			assertThat(returned,equalTo(array));
+		}
+	}
+
+
+
 	@Test
 	public void fromBufferObject() {
 		byte[] buffer = "[{\"value\":\"hello\"},{\"value\":\"world\"}]".getBytes(StandardCharsets.UTF_8);
 
-		TypeRegistry tr = new TypeRegistryImpl();
+		TypeRegistry tr = TypeRegistry.getRegistry();
 		tr.addDataType(MyType.class);
 
 		MetadataBuilder.addComponent(tr.getDataType("MyType"));
@@ -76,7 +175,7 @@ public class JSONTransactionSerializerTest {
 
 	@Test
 	public void toBufferPrimitive() {
-		TypeRegistry tr = new TypeRegistryImpl();
+		TypeRegistry tr = TypeRegistry.getRegistry();
 		JSONTransactionSerializer serializer = new JSONTransactionSerializer();
 		
 
@@ -127,5 +226,8 @@ public class JSONTransactionSerializerTest {
 	}
 
 
+	class MyTestObject {
+		
+	}
 
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/TypeSchemaTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/TypeSchemaTest.java
@@ -18,11 +18,10 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TypeSchemaTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+   
 
     @Before
     public void beforeEach() {
@@ -101,7 +100,28 @@ public class TypeSchemaTest {
         assertThat(ts.getTypeClass(mockRegistry), equalTo(String.class));
 
         ts.put("type", "integer");
+        ts.put("format","int8");
+        assertThat(ts.getTypeClass(mockRegistry), equalTo(byte.class));
+
+        ts.put("type", "integer");
+        ts.put("format","int16");
+        assertThat(ts.getTypeClass(mockRegistry), equalTo(short.class));
+
+        ts.put("type", "integer");
+        ts.put("format","int32");
         assertThat(ts.getTypeClass(mockRegistry), equalTo(int.class));
+
+        ts.put("type", "integer");
+        ts.put("format","int64");
+        assertThat(ts.getTypeClass(mockRegistry), equalTo(long.class));
+
+        ts.put("type", "number");
+        ts.put("format","double");
+        assertThat(ts.getTypeClass(mockRegistry), equalTo(double.class));
+
+        ts.put("type", "number");
+        ts.put("format","float");
+        assertThat(ts.getTypeClass(mockRegistry), equalTo(float.class));
 
         ts.put("type", "boolean");
         assertThat(ts.getTypeClass(mockRegistry), equalTo(boolean.class));
@@ -117,6 +137,25 @@ public class TypeSchemaTest {
         array.put("items", ts);
         assertThat(array.getTypeClass(mockRegistry), equalTo(MyType[].class));
 
+    }
+
+    @Test 
+    public void unkownConversions(){
+        assertThrows(RuntimeException.class, () -> {
+            TypeSchema ts = new TypeSchema();
+            TypeRegistry mockRegistry = new TypeRegistryImpl();
+            ts.put("type", "integer");
+            ts.put("format","int63");
+            ts.getTypeClass(mockRegistry);
+        });
+
+        assertThrows(RuntimeException.class, () -> {
+            TypeSchema ts = new TypeSchema();
+            TypeRegistry mockRegistry = new TypeRegistryImpl();
+            ts.put("type", "number");
+            ts.put("format","aproximate");
+            ts.getTypeClass(mockRegistry);
+        });
     }
 
     @Test


### PR DESCRIPTION
- Objects returned from a transaction function now will not have
  any spurious properties in them
- In testing located handling of array types was wrong; provided
  improved handling for those

Signed-off-by: Matthew B. White <whitemat@uk.ibm.com>