### PR TITLE
Remove -SNAPSHOT from package version variable

### DIFF
--- a/ci/templates/build-data.yml
+++ b/ci/templates/build-data.yml
@@ -2,7 +2,7 @@ steps:
 - script: |
     env | sort
     java -version
-    VERSION=$(cat build.gradle |  sed -n "s/version =.*'\(.*\)\(-SNAPSHOT\)\?'/\1/p")  
+    VERSION=$(./gradlew -q printVersionName | head -n 1 | cut -d'-' -f1)  
     VERSION=${VERSION// }
     echo Current version in code is :${VERSION}:
     echo "##vso[task.setvariable variable=PACKAGE_VERSION;isOutput=true]${VERSION}"


### PR DESCRIPTION
Docker image was being published with an incorrect version of amd64-2.0.0-SNAPSHOT-stable

Signed-off-by: James Taylor <jamest@uk.ibm.com>