### PR TITLE
[FAB-16136] Do not run tests in chaincode container

### DIFF
--- a/fabric-chaincode-docker/build.sh
+++ b/fabric-chaincode-docker/build.sh
@@ -15,9 +15,9 @@ buildGradle() {
     echo "Gradle build"
     if [ -f ./gradlew ]; then
       chmod +x ./gradlew
-      ./gradlew build shadowJar
+      ./gradlew build shadowJar -x test
     else
-      gradle build shadowJar
+      gradle build shadowJar -x test
     fi
     retval=$?
     if [ $retval -ne 0 ]; then
@@ -38,7 +38,7 @@ buildMaven() {
     tar cf - . | (cd ${TMP_DIR}; tar xf -)
     cd ${TMP_DIR}
     echo "Maven build"
-    mvn compile package
+    mvn compile package -DskipTests -Dmaven.test.skip=true
     retval=$?
     if [ $retval -ne 0 ]; then
       exit $retval


### PR DESCRIPTION
Set the gradle and maven rebuilds of the Java code when creating the
chaincode container to not do the tests. These would have been run
before deployment by the deverlopers. Doing so in Java slows down
deployment quite a bit.

Change-Id: Id3ffc2dc9a36c11c7cfe7f41e98aaeb234c478ad
Signed-off-by: Matthew B. White <whitemat@uk.ibm.com>