### PR TITLE
[FABCJ-282] Release 2.0.1 chaincode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0.1
+Wed  4 Mar 16:38:58 GMT 2020
+
+* [8cb6a25](https://github.com/hyperledger/fabric-chaincode-java/commit/8cb6a25) [FAB-16136](https://jira.hyperledger.org/browse/FAB-16136) Do not run tests in chaincode container
+* [3710641](https://github.com/hyperledger/fabric-chaincode-java/commit/3710641) [FABCJ-280](https://jira.hyperledger.org/browse/FABCJ-280) Copy chaincode into temporary directory before building
+* [a25a7d6](https://github.com/hyperledger/fabric-chaincode-java/commit/a25a7d6) [FABCJ-276](https://jira.hyperledger.org/browse/FABCJ-276) Access localmspid
+
 ## v2.0.0
 Fri 24 Jan 10:26:03 GMT 2020
 

--- a/release_notes/v2.0.1.txt
+++ b/release_notes/v2.0.1.txt
@@ -1,0 +1,25 @@
+v2.0.1 4 March 2020
+--------------------------
+
+Release Notes
+-------------
+
+- Provides access to the localmspid
+
+adoptopenjdk/openjdk11:jdk-11.0.4_11-alpine is now used for the basis of javaenv Docker image.
+
+Known Vulnerabilities
+---------------------
+none
+
+Resolved Vulnerabilities
+------------------------
+none
+
+Known Issues & Workarounds
+--------------------------
+none
+
+Change Log
+----------
+https://github.com/hyperledger/fabric-chaincode-java/blob/master/CHANGELOG.md#v201


### PR DESCRIPTION
Provides access to local MSPid

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>