### PR TITLE
[FABCJ-283] Update javadoc 2.x link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,4 +3,4 @@ title: "fabric-chaincode-java"
 releases:
   - master
   - release-1.4
-  - release-2.0
+  - release-2.1


### PR DESCRIPTION
Replace release-2.0 link with release-2.1

Signed-off-by: James Taylor <jamest@uk.ibm.com>