### PR TITLE
[FABCJ-285] Remove incorrect log point

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/ChaincodeInvocationTask.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/ChaincodeInvocationTask.java
@@ -173,12 +173,11 @@ public class ChaincodeInvocationTask implements Callable<ChaincodeMessage> {
         ChaincodeMessage response;
         try {
             response = messageExchange.exchange(null);
-            logger.info(() -> "Got response back from the peer" + response);
+            logger.info(() -> "Got response back from the peer" + response.getTxid());
         } catch (final InterruptedException e) {
             logger.severe(() -> "Interrupted exchanging messages ");
             throw new RuntimeException(String.format("[%-8.8s]InterruptedException received.", txId), e);
         }
-        logger.fine(() -> String.format("[%-8.8s] %s response received.", txId, response.getType()));
 
         // handle response
         switch (response.getType()) {


### PR DESCRIPTION
Changed

            logger.info(() -> "Got response back from the peer" + response);
to 

            logger.info(() -> "Got response back from the peer" + response.getTxid());

Don't do complex work in log points.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>