### PR TITLE
[FABCJ-286] Prepare 2.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 apply plugin: 'idea'
 apply plugin: 'eclipse-wtp'
-version = '2.1.1'
+version = '2.1.2'
 allprojects {
     repositories {
         mavenCentral()

--- a/fabric-chaincode-docker/build.gradle
+++ b/fabric-chaincode-docker/build.gradle
@@ -71,6 +71,6 @@ task copyAllDeps(type: Copy) {
 task buildImage(type: DockerBuildImage) {
     dependsOn copyAllDeps
     inputDir = project.file('Dockerfile').parentFile
-    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:amd64-2.1.1', 'hyperledger/fabric-javaenv:amd64-latest']
+    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:amd64-2.1.2', 'hyperledger/fabric-javaenv:amd64-latest']
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-chaincode-example-sacc/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-chaincode-example-sacc/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.1.1'
+    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.1.2'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-chaincode-example-sbe/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-chaincode-example-sbe/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.1.1'
+    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.1.2'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 


### PR DESCRIPTION
Prepare the next releases
Updated the project build.gralde files to use the version defined
in the root build.gralde.   Fewer updates in future.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>