### PR TITLE
[FABCJ-291] Startkey needs additional checks

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/InvocationStubImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/InvocationStubImpl.java
@@ -64,7 +64,8 @@ import com.google.protobuf.Timestamp;
 
 class InvocationStubImpl implements ChaincodeStub {
 
-    private static final String UNSPECIFIED_KEY = new String(Character.toChars(0x000001));
+    private static final String UNSPECIFIED_START_KEY = new String(Character.toChars(0x000001));
+    private static final String UNSPECIFIED_END_KEY = "";
     private static final Logger LOGGER = Logger.getLogger(InvocationStubImpl.class.getName());
 
     public static final String MAX_UNICODE_RUNE = "\udbff\udfff";
@@ -248,11 +249,11 @@ class InvocationStubImpl implements ChaincodeStub {
         String start = startKey;
         String end = endKey;
 
-        if (startKey == null) {
-            start = UNSPECIFIED_KEY;
+        if (startKey == null || startKey.isEmpty()) {
+            start = UNSPECIFIED_START_KEY;
         }
         if (endKey == null) {
-            end = UNSPECIFIED_KEY;
+            end = UNSPECIFIED_END_KEY;
         }
         CompositeKey.validateSimpleKeys(start, end);
 
@@ -293,11 +294,11 @@ class InvocationStubImpl implements ChaincodeStub {
         String start = startKey;
         String end = endKey;
 
-        if (startKey == null) {
-            start = UNSPECIFIED_KEY;
+        if (startKey == null || startKey.isEmpty()) {
+            start = UNSPECIFIED_START_KEY;
         }
         if (endKey == null) {
-            end = UNSPECIFIED_KEY;
+            end = UNSPECIFIED_END_KEY;
         }
 
         CompositeKey.validateSimpleKeys(start, end);
@@ -350,7 +351,7 @@ class InvocationStubImpl implements ChaincodeStub {
         String cKeyAsString;
 
         if (compositeKey == null) {
-            cKeyAsString = new CompositeKey(UNSPECIFIED_KEY).toString();
+            cKeyAsString = new CompositeKey(UNSPECIFIED_START_KEY).toString();
         } else {
             cKeyAsString = compositeKey.toString();
         }
@@ -365,7 +366,7 @@ class InvocationStubImpl implements ChaincodeStub {
         String cKeyAsString;
 
         if (compositeKey == null) {
-            cKeyAsString = new CompositeKey(UNSPECIFIED_KEY).toString();
+            cKeyAsString = new CompositeKey(UNSPECIFIED_START_KEY).toString();
         } else {
             cKeyAsString = compositeKey.toString();
         }
@@ -520,11 +521,11 @@ class InvocationStubImpl implements ChaincodeStub {
         String end = endKey;
 
         validateCollection(collection);
-        if (startKey == null) {
-            start = UNSPECIFIED_KEY;
+        if (startKey == null || startKey.isEmpty()) {
+            start = UNSPECIFIED_START_KEY;
         }
         if (endKey == null) {
-            end = UNSPECIFIED_KEY;
+            end = UNSPECIFIED_END_KEY;
         }
         CompositeKey.validateSimpleKeys(start, end);
 
@@ -553,7 +554,7 @@ class InvocationStubImpl implements ChaincodeStub {
             final CompositeKey compositeKey) {
         String cKeyAsString;
         if (compositeKey == null) {
-            cKeyAsString = new CompositeKey(UNSPECIFIED_KEY).toString();
+            cKeyAsString = new CompositeKey(UNSPECIFIED_START_KEY).toString();
         } else {
             cKeyAsString = compositeKey.toString();
         }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/InvocationStubImplTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/InvocationStubImplTest.java
@@ -30,6 +30,7 @@ public class InvocationStubImplTest {
 
     private final String channelId = "mychannel";
     private final String txId = "0xCAFEBABE";
+    private final String simpleKeyStartNamespace = new String(Character.toChars(0x000001));
 
     @Nested
     class GetStateByRangeTests {
@@ -80,9 +81,8 @@ public class InvocationStubImplTest {
 
             final GetStateByRange range = GetStateByRange.parseFrom(msg.getPayload());
 
-            final String unspecifiedKey = new String(Character.toChars(0x000001));
-            assertThat(range.getStartKey()).isEqualTo(unspecifiedKey);
-            assertThat(range.getEndKey()).isEqualTo(unspecifiedKey);
+            assertThat(range.getStartKey()).isEqualTo(simpleKeyStartNamespace);
+            assertThat(range.getEndKey()).isEqualTo("");
         }
 
         @Test
@@ -98,7 +98,7 @@ public class InvocationStubImplTest {
 
             final GetStateByRange range = GetStateByRange.parseFrom(msg.getPayload());
 
-            assertThat(range.getStartKey()).isEqualTo("");
+            assertThat(range.getStartKey()).isEqualTo(simpleKeyStartNamespace);
             assertThat(range.getEndKey()).isEqualTo("");
         }
 


### PR DESCRIPTION
For the open ended query, the start and empty keys are empty from the chaincode. However, in the shim, if the start key is an empty key, it is replaced with 0x01  which is nothing but a namespace for the non-composite key.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>