### PR TITLE
Fix "build shadowJar" error

### DIFF
--- a/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
+++ b/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "2.0.3"
+    id("com.github.johnrengelman.shadow") version "5.2.0"
     id("org.jetbrains.kotlin.jvm") version "1.3.41"
 }
 


### PR DESCRIPTION
I caught same error:
```
Receiver class com.github.jengelman.gradle.plugins.shadow.internal.DependencyFileCollection does not define or inherit an implementation of the resolved method 'abstract org.gradle.api.tasks.TaskDependency getBuildDependencies()' of interface org.gradle.api.Buildable.
```
The problem is solved by updating the version of the dependency

Read more: https://github.com/johnrengelman/shadow/issues/447