### PR TITLE
Fix link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,5 +8,5 @@ There are two ways to report a security bug. The easiest is to email a descripti
 
 The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
 


### PR DESCRIPTION
Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

#### Type of change

- Bug fix

#### Description

Fix broken link.

#### Additional details

Incidentally this makes the repo compliant with the common repository structure: https://wiki.hyperledger.org/display/TSC/Projects+have+two+quarters+to+comply+with+common+repo+structure

Run the following to check:

`repolinter --rulesetUrl https://github.com/hyperledger-labs/hyperledger-community-management-tools/raw/main/repo_structure/repolint.json`