### PR TITLE
Logging Tests Reset Correctly

### DIFF
--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggingTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggingTest.java
@@ -83,6 +83,6 @@ public final class LoggingTest {
         assertThat(l.getLevel(), CoreMatchers.equalTo(Level.SEVERE));
         assertThat(another.getLevel(), CoreMatchers.equalTo(anotherLevel));
 
-        Logging.setLogLevel("INFO");
+        Logging.setLogLevel("debug");
     }
 }


### PR DESCRIPTION
Reset the logging results correctly; go back to the debug level as set in the gradle file

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>