### PR TITLE
fix fabric-contract-example-maven/pom.xml

### DIFF
--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -133,7 +133,7 @@
 							<finalName>chaincode</finalName>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>chaincode.example.SimpleChaincode</mainClass>
+									<mainClass>org.hyperledger.fabric.contract.ContractRouter</mainClass>
 								</transformer>
 							</transformers>
 							<filters>


### PR DESCRIPTION
I ran the fabric-contract-example-maven project and found that chaincode reported an error when invoked.

> Error: Could not find or load main class chaincode.example.SimpleChaincode
> Caused by: java.lang.ClassNotFoundException: chaincode.example.SimpleChaincode

Then I made corrections with reference to fabric-contract-example-gradle, and now it can run correctly.