### PR TITLE
Change FABRIC_VERSION to latest tag

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -41,7 +41,7 @@ variables:
   - name: PUSH_VERSION
     value: stable
   - name: FABRIC_VERSION
-    value: 2.1
+    value: latest
 
 pool:
   vmImage: "ubuntu-latest"

--- a/fabric-chaincode-integration-test/getDockerImages.sh
+++ b/fabric-chaincode-integration-test/getDockerImages.sh
@@ -6,17 +6,14 @@
 #
 set -euo pipefail
 
-version=${FABRIC_VERSION:-2.3}
+version=${FABRIC_VERSION:-latest}
 artifactory_url=hyperledger-fabric.jfrog.io
 
-for image in peer orderer tools; do
-    artifactory_image="${artifactory_url}/fabric-${image}:amd64-${version}-stable"
+for image in peer orderer ca tools; do
+    artifactory_image="${artifactory_url}/fabric-${image}:amd64-${version}"
     docker pull -q "${artifactory_image}"
     docker tag "${artifactory_image}" "hyperledger/fabric-${image}"
     docker rmi -f "${artifactory_image}" >/dev/null
 done
 
 docker pull -q hyperledger/fabric-couchdb
-docker pull -q hyperledger/fabric-ca:1.4
-docker tag hyperledger/fabric-ca:1.4 hyperledger/fabric-ca
-docker rmi hyperledger/fabric-ca:1.4 >/dev/null


### PR DESCRIPTION
CI for the default branch should always pull the latest image now that it's available.

Signed-off-by: Brett Logan <lindluni@github.com>