### PR TITLE
Correct condition

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -9,7 +9,7 @@ name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rrr)
 # Daily build for final quality
 # cf https://crontab.guru/#0_23_*_*_*
 schedules:
-  - cron: "0 23 * * *"
+  - cron: "0 10,12,14,16,23 * * *"
     displayName: "Chaincode Java Nightly Driver"
     branches:
       include:
@@ -163,7 +163,7 @@ stages:
   # As the next script is more complex and uses loops, run this discretely in a sh file
   # Publishing step for git tags
   - stage: Publish_tag
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+    condition: and(succeeded('Build_and_test'), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
     jobs:
       - job: docker_publish
         steps:
@@ -207,7 +207,7 @@ stages:
 
               #
   - stage: Publish_tag_nightly
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))  # only run on the scheduled builds
+    condition: and(succeeded('Build_and_test'), eq(variables['Build.Reason'], 'Schedule'))  # only run on the scheduled builds
     jobs:
       - job: jar_publish
         steps:


### PR DESCRIPTION
- looks like the `succeded()` check interpreted the previous stage as being skipped as an error - therefore didn't run the correct publishing
- changed that to be dependent on the specific job
- temporarily adjusted the frequency of the builds
- 
Signed-off-by: Matthew B White <whitemat@uk.ibm.com>