### PR TITLE
NettyGrpcServer -- support mutual TLS

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeServerProperties.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeServerProperties.java
@@ -20,6 +20,7 @@ public final class ChaincodeServerProperties {
     private String keyPassword;
     private String keyCertChainFile;
     private String keyFile;
+    private String trustCertCollectionFile;
     private boolean tlsEnabled = false;
 
     public ChaincodeServerProperties() {
@@ -131,6 +132,14 @@ public final class ChaincodeServerProperties {
 
     public void setKeyFile(String keyFile) {
         this.keyFile = keyFile;
+    }
+
+    public String getTrustCertCollectionFile() {
+        return trustCertCollectionFile;
+    }
+
+    public void setTrustCertCollectionFile(String trustCertCollectionFile) {
+        this.trustCertCollectionFile = trustCertCollectionFile;
     }
 
     public boolean isTlsEnabled() {

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/NettyGrpcServer.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/NettyGrpcServer.java
@@ -11,6 +11,7 @@ import io.grpc.Server;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.grpc.netty.shaded.io.netty.handler.ssl.ApplicationProtocolNames;
+import io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -72,6 +73,12 @@ public final class NettyGrpcServer implements GrpcServer {
                     ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
                     ApplicationProtocolNames.HTTP_2);
             sslContextBuilder.applicationProtocolConfig(apn);
+
+            if (chaincodeServerProperties.getTrustCertCollectionFile() != null) {
+                final File trustCertCollectionFile = Paths.get(chaincodeServerProperties.getTrustCertCollectionFile()).toFile();
+                sslContextBuilder.clientAuth(ClientAuth.REQUIRE);
+                sslContextBuilder.trustManager(trustCertCollectionFile);
+            }
 
             serverBuilder.sslContext(sslContextBuilder.build());
         }


### PR DESCRIPTION
This PR adds functionality to optionally authenticate clients of the Java chaincode gRPC server