### PR TITLE
First argument should be of type Context

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TxFunctionImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/routing/impl/TxFunctionImpl.java
@@ -118,7 +118,9 @@ public final class TxFunctionImpl implements TxFunction {
                 Arrays.asList(method.getParameters()));
 
         // validate the first one is a context object
-        if (!Context.class.isAssignableFrom(params.get(0).getType())) {
+        if (params.size() == 0) {
+            throw new ContractRuntimeException("First argument should be of type Context");
+        } else if (!Context.class.isAssignableFrom(params.get(0).getType())) {
             throw new ContractRuntimeException(
                     "First argument should be of type Context " + method.getName() + " " + params.get(0).getType());
         } else {


### PR DESCRIPTION
A transaction function must have at least one argument, which is of type Context.

Originally, if a transaction function has 0 arguments, the runtime exists. Now with this PR, the runtime gives some cues.