### PR TITLE
cast type to java.nio.Buffer to flip()

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/InvocationStubImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/InvocationStubImpl.java
@@ -129,7 +129,7 @@ class InvocationStubImpl implements ChaincodeStub {
         messageDigest.update(this.creator.asReadOnlyByteBuffer());
         final ByteBuffer epochBytes = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN)
                 .putLong(channelHeader.getEpoch());
-        epochBytes.flip();
+        ((java.nio.Buffer) epochBytes).flip();
         messageDigest.update(epochBytes);
         return messageDigest.digest();
     }


### PR DESCRIPTION
When starting java chaincode as a service with shim 2.2.3 on JDK8, `epochBytes.flip()` throws `java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()`, which would make the response of the invoke request from peer miss, and peer would report timeout.

Signed-off-by: Wu Yiyang <wuyiyang1992@qq.com>