### PR TITLE
For 'application errors' set response to the COMPLETED

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
@@ -74,7 +74,7 @@ public class ContractExecutionService implements ExecutionService {
             final Throwable cause = e.getCause();
 
             if (cause instanceof ChaincodeException) {
-                throw (ChaincodeException) cause;
+                response = ResponseUtils.newErrorResponse(cause);
             } else {
                 throw new ContractRuntimeException("Error during contract method execution", cause);
             }

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ResponseUtils.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ResponseUtils.java
@@ -95,10 +95,12 @@ public final class ResponseUtils {
         if (throwable instanceof ChaincodeException) {
             message = throwable.getMessage();
             payload = ((ChaincodeException) throwable).getPayload();
+            return new Chaincode.Response(INTERNAL_SERVER_ERROR, message, payload);
         } else {
             message = "Unexpected error";
+            return ResponseUtils.newErrorResponse(message, payload);
         }
 
-        return ResponseUtils.newErrorResponse(message, payload);
+
     }
 }

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/ChaincodeInvocationTask.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/ChaincodeInvocationTask.java
@@ -112,8 +112,8 @@ public class ChaincodeInvocationTask implements Callable<ChaincodeMessage> {
                     // Send ERROR with entire result.Message as payload
                     logger.severe(() -> String.format("[%-8.8s] Invoke failed with error code %d. Sending %s",
                             message.getTxid(), result.getStatus().getCode(), ERROR));
-                    finalResponseMessage = ChaincodeMessageFactory.newErrorEventMessage(message.getChannelId(),
-                            message.getTxid(), result.getMessage(), stub.getEvent());
+                    finalResponseMessage = ChaincodeMessageFactory.newCompletedEventMessage(message.getChannelId(),
+                            message.getTxid(), result, stub.getEvent());
                     if (span != null) {
                         span.setStatus(StatusCode.ERROR, result.getMessage());
                     }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/fvt/ChaincodeFVTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/fvt/ChaincodeFVTest.java
@@ -7,7 +7,6 @@ package org.hyperledger.fabric.shim.fvt;
 
 import static org.hamcrest.Matchers.is;
 import static org.hyperledger.fabric.protos.peer.ChaincodeShim.ChaincodeMessage.Type.COMPLETED;
-import static org.hyperledger.fabric.protos.peer.ChaincodeShim.ChaincodeMessage.Type.ERROR;
 import static org.hyperledger.fabric.protos.peer.ChaincodeShim.ChaincodeMessage.Type.INIT;
 import static org.hyperledger.fabric.protos.peer.ChaincodeShim.ChaincodeMessage.Type.READY;
 import static org.hyperledger.fabric.protos.peer.ChaincodeShim.ChaincodeMessage.Type.REGISTER;
@@ -529,7 +528,7 @@ public final class ChaincodeFVTest {
         final ChaincodeBase cb = new ChaincodeBase() {
             @Override
             public Response init(final ChaincodeStub stub) {
-                return ResponseUtils.newErrorResponse("Wrong response1");
+                return ResponseUtils.newErrorResponse("Wrong response1".getBytes());
             }
 
             @Override
@@ -558,8 +557,9 @@ public final class ChaincodeFVTest {
         ChaincodeMockPeer.checkScenarioStepEnded(server, 2, 5000, TimeUnit.MILLISECONDS);
 
         assertThat(server.getLastMessageSend().getType(), is(INIT));
-        assertThat(server.getLastMessageRcvd().getType(), is(ERROR));
-        assertThat(server.getLastMessageRcvd().getPayload().toStringUtf8(), is("Wrong response1"));
+        assertThat(server.getLastMessageRcvd().getType(), is(COMPLETED));
+        String resp1 = (ProposalResponsePackage.Response.parseFrom(server.getLastMessageRcvd().getPayload()).getPayload().toStringUtf8());
+        assertThat(resp1, is("Wrong response1"));
 
         final ByteString invokePayload = Chaincode.ChaincodeInput.newBuilder().build().toByteString();
         final ChaincodeShim.ChaincodeMessage invokeMsg = MessageUtil.newEventMessage(TRANSACTION, "testChannel", "0",
@@ -569,8 +569,9 @@ public final class ChaincodeFVTest {
 
         ChaincodeMockPeer.checkScenarioStepEnded(server, 3, 5000, TimeUnit.MILLISECONDS);
         assertThat(server.getLastMessageSend().getType(), is(TRANSACTION));
-        assertThat(server.getLastMessageRcvd().getType(), is(ERROR));
-        assertThat(server.getLastMessageRcvd().getPayload().toStringUtf8(), is("Wrong response2"));
+        assertThat(server.getLastMessageRcvd().getType(), is(COMPLETED));
+        String resp2 = ProposalResponsePackage.Response.parseFrom(server.getLastMessageRcvd().getPayload()).getMessage().toString();
+        assertThat(resp2, is("Wrong response2"));
     }
 
     @Test


### PR DESCRIPTION
Previously this was set to error which means that the entire chaincode failed, not
a 'good' error from the application level code
Signed-off-by: Matthew B White <whitemat@uk.ibm.com>