### PR TITLE
FCJ-214 improved ChaincodeRuntimeException message

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/impl/ContractExecutionService.java
@@ -76,7 +76,7 @@ public class ContractExecutionService implements ExecutionService {
             if (cause instanceof ChaincodeException) {
                 response = ResponseUtils.newErrorResponse(cause);
             } else {
-                throw new ContractRuntimeException("Error during contract method execution", cause);
+                throw new ContractRuntimeException(String.format("Error during contract method execution: %s", cause.getMessage()), cause);
             }
         }
 

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/ChaincodeInvocationTask.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/ChaincodeInvocationTask.java
@@ -217,8 +217,8 @@ public class ChaincodeInvocationTask implements Callable<ChaincodeMessage> {
                 logger.fine(() -> String.format("[%-8.8s] Successful response received.", txId));
                 return response.getPayload();
             case ERROR:
-                logger.severe(() -> String.format("[%-8.8s] Unsuccessful response received.", txId));
-                throw new RuntimeException(String.format("[%-8.8s]Unsuccessful response received.", txId));
+                logger.severe(() -> String.format("[%-8.8s] Unsuccessful response received: %s.", txId, response.getPayload().toStringUtf8()));
+                throw new RuntimeException(String.format("[%-8.8s]Unsuccessful response received: %s.", txId, response.getPayload().toStringUtf8()));
             default:
                 logger.severe(() -> String.format("[%-8.8s] Unexpected %s response received. Expected %s or %s.", txId,
                         response.getType(), RESPONSE, ERROR));

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContractRouterTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContractRouterTest.java
@@ -346,7 +346,7 @@ public class ContractRouterTest {
         final Chaincode.Response response = r.invoke(s);
         assertThat(response, is(notNullValue()));
         assertThat(response.getStatus(), is(Chaincode.Response.Status.INTERNAL_SERVER_ERROR));
-        assertThat(response.getMessage(), is(equalTo("Error during contract method execution")));
+        assertThat(response.getMessage(), is(equalTo("Error during contract method execution: T3 fail!")));
         assertThat(response.getStringPayload(), is(nullValue()));
         assertThat(SampleContract.getBeforeInvoked(), is(1));
         assertThat(SampleContract.getAfterInvoked(), is(0));


### PR DESCRIPTION
close #214 
improved ChaincodeRuntimeException message by adding payload to message response. So, users can see better described and more informative exception messages.
Signed-off-by: Oleksandr Yamkovyi <oleksandr.yamkoviy@intellecteu.com>