### PR TITLE
Improve the handling of the TLS certifiactes

### DIFF
--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'io.grpc:grpc-netty-shaded:1.34.1'
     implementation 'io.grpc:grpc-protobuf:1.34.1'
     implementation 'io.grpc:grpc-stub:1.34.1'
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.0'
+    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
 
 
     implementation platform("io.opentelemetry:opentelemetry-bom:1.6.0")

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeBase.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeBase.java
@@ -539,7 +539,7 @@ public abstract class ChaincodeBase implements Chaincode {
 
             // set values on the server properties
             chaincodeServerProperties.setTlsEnabled(true);
-            chaincodeServerProperties.setKeyFile(this.tlsClientCertFilePEM);
+            chaincodeServerProperties.setKeyFile(this.tlsClientKeyFilePEM);
             chaincodeServerProperties.setKeyCertChainFile(this.tlsClientCertFilePEM);
         }
         return chaincodeServerProperties;

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeServerProperties.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeServerProperties.java
@@ -18,8 +18,8 @@ public final class ChaincodeServerProperties {
     private int keepAliveTimeMinutes = 1;
     private boolean permitKeepAliveWithoutCalls = true;
     private String keyPassword;
-    private String keyCertChainFile;
-    private String keyFile;
+    private byte[] keyCertChain;
+    private byte[] key;
     private String trustCertCollectionFile;
     private boolean tlsEnabled = false;
 
@@ -117,20 +117,20 @@ public final class ChaincodeServerProperties {
         this.keyPassword = keyPassword;
     }
 
-    public String getKeyCertChainFile() {
-        return keyCertChainFile;
+    public byte[] getKeyCertChain() {
+        return keyCertChain;
     }
 
-    public void setKeyCertChainFile(final String keyCertChainFile) {
-        this.keyCertChainFile = keyCertChainFile;
+    public void setKeyCertChain(final byte[] keyCertChain) {
+        this.keyCertChain = keyCertChain;
     }
 
-    public String getKeyFile() {
-        return keyFile;
+    public byte[] getKey() {
+        return key;
     }
 
-    public void setKeyFile(final String keyFile) {
-        this.keyFile = keyFile;
+    public void setKeyFile(final byte[] key) {
+        this.key = key;
     }
 
     public String getTrustCertCollectionFile() {
@@ -171,8 +171,8 @@ public final class ChaincodeServerProperties {
         if (this.getMaxInboundMessageSize() <= 0) {
             throw new IllegalArgumentException("chaincodeServerProperties.getMaxInboundMessageSize() must be more then 0");
         }
-        if (this.isTlsEnabled() && (this.getKeyCertChainFile() == null || this.getKeyCertChainFile().isEmpty()
-            || this.getKeyFile() == null || this.getKeyFile().isEmpty())) {
+        if (this.isTlsEnabled() && (this.getKeyCertChain() == null 
+            || this.getKey() == null )) {
             throw new IllegalArgumentException("if chaincodeServerProperties.isTlsEnabled() must be more specified"
                 + " chaincodeServerProperties.getKeyCertChainFile() and chaincodeServerProperties.getKeyFile()"
                 + " with optional chaincodeServerProperties.getKeyPassword()");

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/NettyGrpcServer.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/NettyGrpcServer.java
@@ -14,7 +14,7 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.ApplicationProtocolNames;
 import io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import java.util.logging.Logger;
-
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -56,14 +56,15 @@ public final class NettyGrpcServer implements GrpcServer {
                 .maxInboundMessageSize(chaincodeServerProperties.getMaxInboundMessageSize());
 
         if (chaincodeServerProperties.isTlsEnabled()) {
-            final File keyCertChainFile = Paths.get(chaincodeServerProperties.getKeyCertChainFile()).toFile();
-            final File keyFile = Paths.get(chaincodeServerProperties.getKeyFile()).toFile();
+            final byte[] keyCertChain = chaincodeServerProperties.getKeyCertChain();
+            final byte[] key = chaincodeServerProperties.getKey();
 
             SslContextBuilder sslContextBuilder;
             if (chaincodeServerProperties.getKeyPassword() == null || chaincodeServerProperties.getKeyPassword().isEmpty()) {
-                sslContextBuilder = SslContextBuilder.forServer(keyCertChainFile, keyFile);
+                // sslContextBuilder = SslContextBuilder.forServer(keyCertChainFile, keyFile);
+                sslContextBuilder = SslContextBuilder.forServer(new ByteArrayInputStream(keyCertChain), new ByteArrayInputStream(key));
             } else {
-                sslContextBuilder = SslContextBuilder.forServer(keyCertChainFile, keyFile, chaincodeServerProperties.getKeyPassword());
+                sslContextBuilder = SslContextBuilder.forServer(new ByteArrayInputStream(keyCertChain), new ByteArrayInputStream(key), chaincodeServerProperties.getKeyPassword());
             }
 
             ApplicationProtocolConfig apn = new ApplicationProtocolConfig(
@@ -91,9 +92,9 @@ public final class NettyGrpcServer implements GrpcServer {
         LOGGER.info("PermitKeepAliveTimeMinutes:" + chaincodeServerProperties.getPermitKeepAliveTimeMinutes());
         LOGGER.info("KeepAliveTimeMinutes:" + chaincodeServerProperties.getKeepAliveTimeMinutes());
         LOGGER.info("PermitKeepAliveWithoutCalls:" + chaincodeServerProperties.getPermitKeepAliveWithoutCalls());
-        LOGGER.info("KeyPassword:" + chaincodeServerProperties.getKeyPassword());
-        LOGGER.info("KeyCertChainFile:" + chaincodeServerProperties.getKeyCertChainFile());
-        LOGGER.info("KeyFile:" + chaincodeServerProperties.getKeyFile());
+        LOGGER.info("KeyPassword:" + chaincodeServerProperties.getKeyPassword()!=null ? "<set>":"<unset>");
+        LOGGER.info("KeyCertChain:" + chaincodeServerProperties.getKeyCertChain()!=null ? "<set>":"<unset>");
+        LOGGER.info("Key:" + chaincodeServerProperties.getKey()!=null ? "<set>":"<unset>");
         LOGGER.info("isTlsEnabled:" + chaincodeServerProperties.isTlsEnabled());
         LOGGER.info("\n");
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeBaseTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeBaseTest.java
@@ -149,9 +149,6 @@ public class ChaincodeBaseTest {
         assertEquals("Host incorrect", cb.getHost(), "localhost");
         assertEquals("Port incorrect", cb.getPort(), 7052);
         assertTrue("TLS should be enabled", cb.isTlsEnabled());
-        assertEquals("Root certificate file", "non_exist_path1", cb.getTlsClientRootCertPath());
-        assertEquals("Client key file", "non_exist_path2", cb.getTlsClientKeyPath());
-        assertEquals("Client certificate file", "non_exist_path3", cb.getTlsClientCertPath());
 
         environmentVariables.set("CORE_PEER_ADDRESS", "localhost1");
         cb.processEnvironmentOptions();


### PR DESCRIPTION
For reasons lost in history, Fabric hasn't standised on whether to load certs in base64 or
PEM format. What does seem to be standard is if the environment variable ends in FILE then
it's a PEM format, but if it's PATH then it's base64.

This change will allow either FILE or PATH environment variables to be used in all cases.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>