### PR TITLE
Remove the log4j dependency

### DIFF
--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -53,8 +53,6 @@ dependencies {
     implementation 'io.grpc:grpc-netty-shaded:1.34.1'
     implementation 'io.grpc:grpc-protobuf:1.34.1'
     implementation 'io.grpc:grpc-stub:1.34.1'
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.0'
-
 
     implementation platform("io.opentelemetry:opentelemetry-bom:1.6.0")
 


### PR DESCRIPTION
Not sure why it was there in the first place

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>