### PR TITLE
Fix transaction serializer usage

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/ExecutionFactory.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/contract/execution/ExecutionFactory.java
@@ -8,11 +8,11 @@ package org.hyperledger.fabric.contract.execution;
 
 import org.hyperledger.fabric.contract.execution.impl.ContractExecutionService;
 import org.hyperledger.fabric.contract.execution.impl.ContractInvocationRequest;
+import org.hyperledger.fabric.contract.routing.impl.SerializerRegistryImpl;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
 public class ExecutionFactory {
     private static ExecutionFactory rf;
-    private static ExecutionService es;
 
     /**
      * @return ExecutionFactory
@@ -36,10 +36,7 @@ public class ExecutionFactory {
      * @param serializers Instance of the serializer
      * @return Execution Service
      */
-    public ExecutionService createExecutionService(final SerializerInterface serializers) {
-        if (es == null) {
-            es = new ContractExecutionService(serializers);
-        }
-        return es;
+    public ExecutionService createExecutionService(final SerializerRegistryImpl serializers) {
+        return new ContractExecutionService(serializers);
     }
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/ContractExecutionServiceTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/ContractExecutionServiceTest.java
@@ -6,6 +6,30 @@
 
 package org.hyperledger.fabric.contract.execution;
 
+import contract.SampleContract;
+import org.hyperledger.fabric.contract.ChaincodeStubNaiveImpl;
+import org.hyperledger.fabric.contract.Context;
+import org.hyperledger.fabric.contract.ContractInterface;
+import org.hyperledger.fabric.contract.ContractRuntimeException;
+import org.hyperledger.fabric.contract.annotation.Serializer;
+import org.hyperledger.fabric.contract.execution.impl.ContractExecutionService;
+import org.hyperledger.fabric.contract.metadata.TypeSchema;
+import org.hyperledger.fabric.contract.routing.ParameterDefinition;
+import org.hyperledger.fabric.contract.routing.TxFunction;
+import org.hyperledger.fabric.contract.routing.impl.ParameterDefinitionImpl;
+import org.hyperledger.fabric.contract.routing.impl.SerializerRegistryImpl;
+import org.hyperledger.fabric.shim.Chaincode.Response;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Collections;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -13,23 +37,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-
-import org.hyperledger.fabric.contract.ChaincodeStubNaiveImpl;
-import org.hyperledger.fabric.contract.Context;
-import org.hyperledger.fabric.contract.ContractInterface;
-import org.hyperledger.fabric.contract.ContractRuntimeException;
-import org.hyperledger.fabric.contract.execution.impl.ContractExecutionService;
-import org.hyperledger.fabric.contract.routing.TxFunction;
-import org.hyperledger.fabric.shim.Chaincode.Response;
-import org.hyperledger.fabric.shim.ChaincodeStub;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import contract.SampleContract;
 
 public class ContractExecutionServiceTest {
     @Rule
@@ -39,10 +46,9 @@ public class ContractExecutionServiceTest {
     @Test
     public void noReturnValue()
             throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException, SecurityException {
-
         JSONTransactionSerializer jts = new JSONTransactionSerializer();
-
-        ContractExecutionService ces = new ContractExecutionService(jts);
+        SerializerRegistryImpl serializerRegistry = spy(new SerializerRegistryImpl());
+        ContractExecutionService ces = new ContractExecutionService(serializerRegistry);
 
         ContractInterface contract = spy(new SampleContract());
         TxFunction txFn = mock(TxFunction.class);
@@ -55,6 +61,7 @@ public class ContractExecutionServiceTest {
         when(req.getArgs()).thenReturn(new ArrayList<byte[]>());
         when(routing.getMethod()).thenReturn(SampleContract.class.getMethod("noReturn", new Class<?>[] {Context.class}));
         when(routing.getContractInstance()).thenReturn(contract);
+        when(serializerRegistry.getSerializer(any(), any())).thenReturn(jts);
         ces.executeRequest(txFn, req, stub);
 
         verify(contract).beforeTransaction(any());
@@ -65,9 +72,9 @@ public class ContractExecutionServiceTest {
     @Test()
     public void failureToInvoke()
             throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException, SecurityException {
-
         JSONTransactionSerializer jts = new JSONTransactionSerializer();
-        ContractExecutionService ces = new ContractExecutionService(jts);
+        SerializerRegistryImpl serializerRegistry = spy(new SerializerRegistryImpl());
+        ContractExecutionService ces = new ContractExecutionService(serializerRegistry);
 
         spy(new SampleContract());
         TxFunction txFn = mock(TxFunction.class);
@@ -83,6 +90,7 @@ public class ContractExecutionServiceTest {
 
         when(routing.getContractInstance()).thenThrow(IllegalAccessException.class);
         when(routing.toString()).thenReturn("MockMethodName:MockClassName");
+        when(serializerRegistry.getSerializer(any(), any())).thenReturn(jts);
 
         thrown.expect(ContractRuntimeException.class);
         thrown.expectMessage("Could not execute contract method: MockMethodName:MockClassName");
@@ -91,4 +99,51 @@ public class ContractExecutionServiceTest {
         assertThat(resp.getStatusCode(), equalTo(500));
     }
 
+    @SuppressWarnings({ "serial" })
+    @Test()
+    public void invokeWithDifferentSerializers()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+        JSONTransactionSerializer defaultSerializer = spy(new JSONTransactionSerializer());
+        SerializerInterface customSerializer = mock(SerializerInterface.class);
+        SerializerRegistryImpl serializerRegistry = spy(new SerializerRegistryImpl());
+        ExecutionService executionService = ExecutionFactory.getInstance().createExecutionService(serializerRegistry);
+
+        TxFunction txFn = mock(TxFunction.class);
+        InvocationRequest req = mock(InvocationRequest.class);
+        TxFunction.Routing routing = mock(TxFunction.Routing.class);
+
+        TypeSchema ts = TypeSchema.typeConvert(String.class);
+        Method method = SampleContract.class.getMethod("t1", Context.class, String.class);
+        Parameter[] params = method.getParameters();
+        ParameterDefinition pd = new ParameterDefinitionImpl("arg1", String.class, ts, params[1]);
+
+        byte[] arg = "asdf".getBytes();
+        ChaincodeStub stub = new ChaincodeStubNaiveImpl();
+        ContractInterface contract = spy(new SampleContract());
+
+        when(req.getArgs()).thenReturn(Collections.singletonList(arg));
+        when(txFn.getRouting()).thenReturn(routing);
+        when(txFn.getParamsList()).thenReturn(Collections.singletonList(pd));
+        when(txFn.getReturnSchema()).thenReturn(ts);
+        when(routing.getMethod()).thenReturn(method);
+        when(routing.getContractInstance()).thenReturn(contract);
+
+        String defaultSerializerName = defaultSerializer.getClass().getCanonicalName();
+        String customSerializerName = "customSerializer";
+
+        // execute transaction with the default serializer
+        when(routing.getSerializerName()).thenReturn(defaultSerializerName);
+        when(serializerRegistry.getSerializer(defaultSerializerName, Serializer.TARGET.TRANSACTION))
+                .thenReturn(defaultSerializer);
+        executionService.executeRequest(txFn, req, stub);
+
+        // execute transaction with the custom serializer
+        when(routing.getSerializerName()).thenReturn(customSerializerName);
+        when(serializerRegistry.getSerializer(customSerializerName, Serializer.TARGET.TRANSACTION))
+                .thenReturn(customSerializer);
+        executionService.executeRequest(txFn, req, stub);
+
+        verify(defaultSerializer).fromBuffer(arg, ts);
+        verify(customSerializer).fromBuffer(arg, ts);
+    }
 }


### PR DESCRIPTION
Fixes the issue of having a single transaction serializer in use for
all contracts regardless of configuration. The issue was due to
having a singleton instance of ExecutionService that had only one
associated serializer. Thus, the first used serializer was also used
for all other transactions. The fix removes this singleton and replaces
it with a ContractRouter field.

#225

Signed-off-by: Bogdan Repeta <github@foglie.33mail.com>