### PR TITLE
JSONPropertyIgnore only works on getter

### DIFF
--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/MyType.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/MyType.java
@@ -21,7 +21,6 @@ public final class MyType {
     public static final  String STARTED = "STARTED";
     public static final  String STOPPED = "STOPPED";
 
-    @JSONPropertyIgnore()
     public void setState(final String state) {
         this.state = state;
     }


### PR DESCRIPTION
The documentation of JSONPropertyIgnore https://github.com/stleary/JSON-java/blob/master/src/main/java/org/json/JSONPropertyIgnore.java says it only works on getters

so I remove it to reduce confusion.