### PR TITLE
Add test for Logger.debug

### DIFF
--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggerTest.java
@@ -36,4 +36,9 @@ public class LoggerTest {
         logger.error(() -> "all gone wrong");
 
     }
+
+    @Test
+    public void testDebug() {
+        Logger.getLogger(LoggerTest.class).debug("debug message");
+    }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that calling `Logger.getLogger(LoggerTest.class).debug("debug message")` does not throw an exception.
This tests the method [`Logger.debug`](https://github.com/hyperledger/fabric-chaincode-java/blob/d1d093b42324230f55410fda3c9efb1663859380/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/Logger.java#L45).
This test is based on the test [`logger`](https://github.com/hyperledger/fabric-chaincode-java/blob/d1d093b42324230f55410fda3c9efb1663859380/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggerTest.java#L19).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))