### PR TITLE
Path Traversal vulnerability

### DIFF
--- a/fabric-chaincode-integration-test/src/contracts/bare-maven/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/fabric-chaincode-integration-test/src/contracts/bare-maven/.mvn/wrapper/MavenWrapperDownloader.java
@@ -104,6 +104,9 @@ public class MavenWrapperDownloader {
                     return new PasswordAuthentication(username, password);
                 }
             });
+        if (!outputFile.getCanonicalPath().startsWith(dir.getCanonicalPath() + File.separator)
+            || (!parentFile.isDirectory() && !parentFile.mkdirs())) {
+            throw new IOException("Could not extract " + entry.getName() + " to " + dir.getPath());
         }
         URL website = new URL(urlString);
         ReadableByteChannel rbc;


### PR DESCRIPTION
Primary Changes to ```/fabric-chaincode-integration-test/src/contracts/bare-maven/.mvn/wrapper/MavenWrapperDownloader.java```

### Description:-

Unsanitized input from a command line argument flows into java.io.FileOutputStream, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to write to arbitrary files.