### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,6 @@ Maintainers
 | Name                      | GitHub           | Chat          | email                     |
 |---------------------------|------------------|---------------|---------------------------|
 | Artem Barger              | c0rwin           | c0rwin        | bartem@il.ibm.com         |
-| Gennady Laventman         | gennadylaventman | gennadyl      | gennady@il.ibm.com        |
 | James Taylor              | jt-nti           | jtonline      | jamest@uk.ibm.com         |
 | Matthew B White           | mbwhite          | mbwhite       | whitemat@uk.ibm.com       |
 
@@ -16,6 +15,7 @@ Retired Maintainers
 | Name                      | GitHub           | Chat          | email                     |
 |---------------------------|------------------|---------------|---------------------------|
 | Gari Singh                | mastersingh24    | mastersingh24 | gari.r.singh@gmail.com    |
+| Gennady Laventman         | gennadylaventman | gennadyl      | gennady@il.ibm.com        |
 | Jim Zhang                 | jimthematrix     | jimthematrix   | jim\_the\_matrix@hotmail.com        |
 | Luis Sanchez              | sanchezl         | sanchezl       | sanchezl@us.ibm.com                 |
 | Srinivasan Muralidharan   | muralisrini      | muralisr       | srinivasan.muralidharan99@gmail.com |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>