### PR TITLE
Fix TLS setup for chaincode server

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeBase.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeBase.java
@@ -539,7 +539,7 @@ public abstract class ChaincodeBase implements Chaincode {
 
             // set values on the server properties
             chaincodeServerProperties.setTlsEnabled(true);
-            chaincodeServerProperties.setKeyFile(this.tlsClientCertFile);
+            chaincodeServerProperties.setKeyFile(this.tlsClientKeyFile);
             chaincodeServerProperties.setKeyCertChainFile(this.tlsClientCertFile);
         }
         return chaincodeServerProperties;


### PR DESCRIPTION
There was a typo which copied certificate file path into the TLS private key file property. This commit fixes the issue.

Change-Id: I41e4d3ecbf48a465b7a42fdfecc21cdb90ce8f1f
Signed-off-by: Artem Barger <artem@bargr.net>