### PR TITLE
Post branch swap cleanup

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ name: Pull request
 on:
   pull_request:
     branches:
-      - release-2.5
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -22,4 +22,4 @@ jobs:
     name: Pull request success
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: "true"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ name: Push
 on:
   push:
     branches:
-      - release-2.5
+      - main
   workflow_dispatch:
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 apply plugin: 'idea'
 apply plugin: 'eclipse-wtp'
-version = '2.5.0'
+version = '2.5.1'
 
 
 // If the nightly property is set, then this is the scheduled main 

--- a/fabric-chaincode-docker/Dockerfile
+++ b/fabric-chaincode-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16.1_1-jdk as builder
+FROM eclipse-temurin:11.0.18_10-jdk as builder
 ENV DEBIAN_FRONTEND=noninteractive 
 
 # Build tools
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-c"]
 RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install gradle 7.0
 RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install maven 3.8.1
 
-FROM eclipse-temurin:11.0.16.1_1-jdk as dependencies
+FROM eclipse-temurin:11.0.18_10-jdk as dependencies
 
 COPY --from=builder /root/.sdkman/candidates/gradle/current /usr/bin/gradle
 COPY --from=builder /root/.sdkman/candidates/maven/current /usr/bin/maven
@@ -54,7 +54,7 @@ RUN mvn -N io.takari:maven:wrapper
 
 # Creating final javaenv image which will include all required
 # dependencies to build and compile java chaincode
-FROM eclipse-temurin:11.0.16.1_1-jdk
+FROM eclipse-temurin:11.0.18_10-jdk
 
 RUN apt-get update \
     && apt-get -y install zip unzip \       

--- a/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.0'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.1'
     implementation group: 'org.hyperledger.fabric', name:'fabric-protos', version:'0.1.3'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'

--- a/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.0</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
 
 		<!-- Logging -->
 		<logback.version>1.2.0</logback.version>

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.0'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.1'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.0'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.1'
     implementation group: 'org.hyperledger.fabric', name:'fabric-protos', version:'0.1.3'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'

--- a/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.0</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
 
 		<!-- Logging -->
 		<logback.version>1.2.0</logback.version>


### PR DESCRIPTION
- Update to the latest patch level of the JDK
- Set version to be 2.5.1
- Tweak the github actions paths to focus on the main branch rather than release-2.5