### PR TITLE
Update dependencies to address security vulnerabilities

### DIFF
--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.75'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.75'
     implementation 'io.github.classgraph:classgraph:4.8.161'
-    implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.1'
-    implementation 'org.json:json:20220320'
+    implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.2'
+    implementation 'org.json:json:20230618'
     implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.19.6'
     
     // Required if using Java 11+ as no longer bundled in the core libraries

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -8,7 +8,7 @@
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:7.4.3'
+        classpath 'org.owasp:dependency-check-gradle:8.2.1'
     }
 }
 

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -47,13 +47,13 @@ dependencies {
     implementation 'io.github.classgraph:classgraph:4.8.161'
     implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.1'
     implementation 'org.json:json:20220320'
-    implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.20.1'
+    implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.19.6'
     
     // Required if using Java 11+ as no longer bundled in the core libraries
     testImplementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
-    implementation 'io.grpc:grpc-netty-shaded:1.56.1'
-    implementation 'io.grpc:grpc-protobuf:1.56.1'
-    implementation 'io.grpc:grpc-stub:1.56.1'
+    implementation 'io.grpc:grpc-netty-shaded:1.45.4'
+    implementation 'io.grpc:grpc-protobuf:1.45.4'
+    implementation 'io.grpc:grpc-stub:1.45.4'
 
     implementation platform("io.opentelemetry:opentelemetry-bom:1.6.0")
 

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -42,9 +42,9 @@ tasks.withType(org.gradle.api.tasks.testing.Test) {
 
 dependencies {
     implementation group: 'org.hyperledger.fabric', name:'fabric-protos', version:'0.2.0'
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.62'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.62'
-    implementation group: 'io.github.classgraph', name: 'classgraph', version: '4.8.146'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.75'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.75'
+    implementation 'io.github.classgraph:classgraph:4.8.161'
     implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.1'
     implementation 'org.json:json:20220320'
     implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.20.1'

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -51,9 +51,9 @@ dependencies {
     
     // Required if using Java 11+ as no longer bundled in the core libraries
     testImplementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
-    implementation 'io.grpc:grpc-netty-shaded:1.46.0'
-    implementation 'io.grpc:grpc-protobuf:1.46.0'
-    implementation 'io.grpc:grpc-stub:1.46.0'
+    implementation 'io.grpc:grpc-netty-shaded:1.56.1'
+    implementation 'io.grpc:grpc-protobuf:1.56.1'
+    implementation 'io.grpc:grpc-stub:1.56.1'
 
     implementation platform("io.opentelemetry:opentelemetry-bom:1.6.0")
 


### PR DESCRIPTION
- CVE-2020-15522
- CVE-2023-32732
- CVE-2022-3171
- CVE-2022-3509
- CVE-2022-3510
- CVE-2022-45688

Also update dependency-check version.

Contributes to #307