### PR TITLE
Move to org.json:json 20231013.

### DIFF
--- a/examples/fabric-contract-example-as-service/build.gradle
+++ b/examples/fabric-contract-example-as-service/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.3.+'
-    compile 'org.json:json:20230618'
+    compile 'org.json:json:20231013'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
+++ b/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
@@ -20,7 +20,7 @@ java {
 
 dependencies {
     implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.0")
-    implementation("org.json:json:20230618")
+    implementation("org.json:json:20231013")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
            
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.2")

--- a/examples/fabric-contract-example-gradle/build.gradle
+++ b/examples/fabric-contract-example-gradle/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.0'
-    compile 'org.json:json:20230618'
+    compile 'org.json:json:20231013'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20230618</version>
+			<version>20231013</version>
 		</dependency>
 
 	</dependencies>

--- a/examples/ledger-api/build.gradle
+++ b/examples/ledger-api/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.4.5'
-    compile 'org.json:json:20230618'
+    compile 'org.json:json:20231013'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/fabric-chaincode-integration-test/build.gradle
+++ b/fabric-chaincode-integration-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation project(':fabric-chaincode-docker')
     implementation project(':fabric-chaincode-shim')
-    implementation 'org.json:json:20230618'
+    implementation 'org.json:json:20231013'
 }
 
 

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk18on:1.76'
     implementation 'io.github.classgraph:classgraph:4.8.162'
     implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.2'
-    implementation 'org.json:json:20230618'
+    implementation 'org.json:json:20231013'
     implementation 'com.google.protobuf:protobuf-java-util:3.22.5'
     
     // Required if using Java 11+ as no longer bundled in the core libraries


### PR DESCRIPTION
As per https://github.com/hyperledger/fabric-chaincode-java/issues/312, and also per https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-5072, the newest version of org.json:json should be used.