### PR TITLE
Prepare for v2.5.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -59,8 +59,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.checkout-ref }}
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'
@@ -41,10 +41,10 @@ jobs:
   intergationtest:  
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout-ref }}
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changelog
+
+Notable changes in each release are documented on the project's [GitHub releases](https://github.com/hyperledger/fabric-chaincode-java/releases) page. Change history from previous releases is retained below.
+
 ## v2.5.0
 Thu Dec  8 09:02:17 GMT 2022
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -16,23 +16,23 @@ This table shows the summary of the compatibility of the Java libraries, togethe
 
 
 Testing is performed with 
- - Java v8: Openjdk version  1.8.0_222
- - Java v11: Eclipse Temurin 11.0.16.1_1-jdk (this has changed from Openjdk version 11.04_11)
+ - Java v8: OpenJDK
+ - Java v11: Eclipse Temurin (this has changed from OpenJDK)
  
 
 By default a Fabric Peer v1.4 will create a Java 8 VM, and a Fabric Peer v2.x will create a Java 11 VM. Whilst is the default, the docker image used to host the chaincode and contracts can be altered.  Set the environment variable `CORE_CHAINCODE_JAVA_RUNTIME` on the peer to the name of the docker image. For example `CORE_CHAINCODE_JAVA_RUNTIME=example/customJavaRuntime:latest`
 
-The Java Libraries will connect to the peer whilst running; this is referred to as 'Fabric Peer Connectivity' in the table. For example, whilst the Fabric Peer v1.4 will create a Java 8 environment, if a Java 11 environment was configured, the Java Libraries at v2.5.0 still function when connecting to the Fabric Peer v1.4.
+The Java Libraries will connect to the peer whilst running; this is referred to as 'Fabric Peer Connectivity' in the table. For example, whilst the Fabric Peer v1.4 will create a Java 8 environment, if a Java 11 environment was configured, the Java Libraries at v2.5 still function when connecting to the Fabric Peer v1.4.
 
 ## Compatibility
 
-The key elements are : 
+The key elements are:
 
 - the version of the Fabric Contract Java libraries used
 - the version of the JVM used to run the code
 - When starting a chaincode container to run a Smart Contract the version of the runtime that is used is determined by these factors:
 
-Fabric v1.4.2, and Fabric v2.5.0 will, by default, start up docker image to host the chaincode and contracts. The version of the docker image used is defined by the version of Fabric in use.
+Fabric v1.4.2, and Fabric v2.5.x will, by default, start up docker image to host the chaincode and contracts. The version of the docker image used is defined by the version of Fabric in use.
 
 With Fabric v2.1.0 and later, the chaincode container can be configured to be started by different chaincode builders, and not the Peer. In this case, the environment used is not in the control of Fabric.
 
@@ -40,30 +40,29 @@ The Java libraries are produced are `group: 'org.hyperledger.fabric-chaincode-ja
 
 ### Supported JVMs
 
-v1.4.x and v2.5.0 Java Libraries are supported running in Java 11 with the x86_64 architecture. Later Java 11 versions are supported but are not tested.
+v1.4.x and v2.5.x Java Libraries are supported running in Java 11 with the x86_64 architecture. Later Java 11 versions are supported but are not tested.
 
-v1.4.x Java Libraries are supported running in Java 8 with the  x86_64 architecture. Later Java 8 versions are supported but are not tested.
+v1.4.x Java Libraries are supported running in Java 8 with the x86_64 architecture. Later Java 8 versions are supported but are not tested.
 
-Architecture Support: all docker images, JVMs, tools are tested under x86_64 ONLY
+Architecture Support: all docker images, JVMs, tools are tested under x86_64 ONLY
 
 
+### Default Peer Runtime selection
 
-### Default Peer Runtime selection
+When using Fabric v2.5, the default docker image that is used to run the Java chaincode is *eclipse-temurin:11.0.21_9-jdk*
 
-When using Fabric 2.5.0, the default docker image that is used to run the Java chaincode is *eclipse-temurin:11.0.16.1_1-jdk*
-
-With the default docker image used by Fabric 2.5.0, if the packaged Java code contains a build script or a wrapper for either Maven or Gradle, it will be built using Gradle 7.0 wrapper , or Maven 3.8.1 wrapper.  
+With the default docker image used by Fabric v2.5, if the packaged Java code contains a build script or a wrapper for either Maven or Gradle, it will be built using Gradle 7.0 wrapper, or Maven 3.8.1 wrapper.  
 
     - If both Gradle and Maven files are present Gradle is used.  
     - Gradle build files can be groovy, or kotlin.  
     - If the Gradle or Maven wrappers are present, this will used in preference to the installed wrappers.
     
-Remeber that when using the wrappers, code will be downloaded from the internet. Keep this in mind for any installation with limited or no internet access.
+Remember that when using the wrappers, code will be downloaded from the internet. Keep this in mind for any installation with limited or no internet access.
     
 Alternatively it is recommended to package prebuilt jar files, including the contract and all dependencies, in which case no build or Internet access is required when installing Java chaincode.
 
 Please check the [Dockerfile](./fabric-chaincode-docker/Dockerfile) that is used for the environment to see exactly how these versions are installed. 
 
 ### Supported Runtime communication with the Peer
- 
-Subject to a suitable runtime environment, the 1.4 and 2.5 Java Libraries can used to communicate with Fabric Peers at 2.5 and previous LTS versions. The level of functionality that is implied by the Fabric version in use and channel capabilities. 
+
+Subject to a suitable runtime environment, the 1.4 and 2.5 Java Libraries can used to communicate with Fabric Peers at 2.5 and previous LTS versions. The level of functionality that is implied by the Fabric version in use and channel capabilities.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,10 +18,6 @@ The following tasks are required before releasing:
 - Update version numbers in `build.gradle` files to the required version
 - Update test, sample, and docs files to match the new version
 - Update the [`COMPATIBILITY.md`](./COMPATIBILITY.md) 
-- Create a new release notes file
-- Update the [`CHANGELOG.md`](./CHANGELOG.md) file
-
-  The `changelog.sh` script in `scripts` will prepopulate the changelog but you must check and edit the file manually afterwards as required
 
 See the [[FABCJ-289] release: 2.2.0 LTS](https://github.com/hyperledger/fabric-chaincode-java/pull/124) pull request for an example, although be careful to search for all versions in the codebase as they're easy to miss and things change!
 

--- a/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
+++ b/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
@@ -19,7 +19,7 @@ java {
 
 
 dependencies {
-    implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.0")
+    implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1")
     implementation("org.json:json:20231013")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
            

--- a/examples/fabric-contract-example-gradle/build.gradle
+++ b/examples/fabric-contract-example-gradle/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.0'
+    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.5.1'
     compile 'org.json:json:20231013'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.0</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
 
 		<!-- Logging -->
 		<logback.version>1.3.14</logback.version>

--- a/fabric-chaincode-docker/Dockerfile
+++ b/fabric-chaincode-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.18_10-jdk as builder
+FROM eclipse-temurin: 11.0.21_9-jdk as builder
 ENV DEBIAN_FRONTEND=noninteractive 
 
 # Build tools
@@ -10,10 +10,10 @@ RUN curl -s "https://get.sdkman.io" | bash
 
 SHELL ["/bin/bash", "-c"]
 
-RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install gradle 7.0
-RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install maven 3.8.1
+RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install gradle 7.6.3
+RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install maven 3.9.5
 
-FROM eclipse-temurin:11.0.18_10-jdk as dependencies
+FROM eclipse-temurin: 11.0.21_9-jdk as dependencies
 
 COPY --from=builder /root/.sdkman/candidates/gradle/current /usr/bin/gradle
 COPY --from=builder /root/.sdkman/candidates/maven/current /usr/bin/maven
@@ -54,7 +54,7 @@ RUN mvn -N io.takari:maven:wrapper
 
 # Creating final javaenv image which will include all required
 # dependencies to build and compile java chaincode
-FROM eclipse-temurin:11.0.18_10-jdk
+FROM eclipse-temurin: 11.0.21_9-jdk
 
 RUN apt-get update \
     && apt-get -y install zip unzip \       

--- a/fabric-chaincode-docker/build.gradle
+++ b/fabric-chaincode-docker/build.gradle
@@ -66,6 +66,6 @@ task copyAllDeps(type: Copy) {
 task buildImage(type: DockerBuildImage) {
     dependsOn copyAllDeps
     inputDir = project.file('Dockerfile').parentFile
-    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:amd64-2.5.0', 'hyperledger/fabric-javaenv:amd64-latest']
+    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:amd64-2.5.1', 'hyperledger/fabric-javaenv:amd64-latest']
 }
 

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -22,7 +22,7 @@ plugins {
 apply plugin: 'org.owasp.dependencycheck'
 
 checkstyle {
-    toolVersion '10.12.2'
+    toolVersion '10.12.5'
     configFile file("../ci/checkstyle/checkstyle.xml")
     configProperties = [root_dir: file("..") ]
 }
@@ -49,7 +49,7 @@ dependencies {
     implementation 'org.hyperledger.fabric:fabric-protos:0.2.1'
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.77'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
-    implementation 'io.github.classgraph:classgraph:4.8.162'
+    implementation 'io.github.classgraph:classgraph:4.8.165'
     implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.2'
     implementation 'org.json:json:20231013'
     implementation 'com.google.protobuf:protobuf-java-util:3.24.4'
@@ -57,7 +57,7 @@ dependencies {
     // Required if using Java 11+ as no longer bundled in the core libraries
     testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
 
-    implementation platform('io.grpc:grpc-bom:1.59.0')
+    implementation platform('io.grpc:grpc-bom:1.60.0')
     implementation 'io.grpc:grpc-netty-shaded'
     implementation 'io.grpc:grpc-protobuf'
     implementation 'io.grpc:grpc-stub'


### PR DESCRIPTION
- Update version numbers.
- Update GitHub Actions versions.
- Update base Java 11 Docker image patch level.
- Update dependencies.