### PR TITLE
Move Maven Contract Example to latest fabric-protos.

### DIFF
--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.hyperledger.fabric</groupId>
 			<artifactId>fabric-protos</artifactId>
-			<version>0.1.3</version>
+			<version>0.2.1</version>
 			<scope>compile</scope>
 		</dependency>
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-3509, https://nvd.nist.gov/vuln/detail/CVE-2022-3171, and https://nvd.nist.gov/vuln/detail/CVE-2022-3510 all indicate issues with the `protobuf-java` dependency before a certain version.  The `fabric-protos` dependency at `0.2.1` is where most of the rest of this project sits, and it has no vulnerabilities.   Particularly, it uses `protobuf-java` v3.24.4. However, `fabric-protos` v0.1.3 imports an earlier version.  This **should** fix that problem.