### PR TITLE
Use secure version of JUnit v4 for compilation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
         testImplementation 'org.mockito:mockito-core:2.23.0'
         testImplementation 'com.github.stefanbirkner:system-rules:system-rules-1.17.0'
 
-        testCompileOnly 'junit:junit:4.12'
+        testCompileOnly 'junit:junit:4.13.2'
         testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.3.1'
         testImplementation 'org.assertj:assertj-core:3.9.1'
     }


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-15250 indicates that `junit:junit:4.12` is insecure. But it has been patched and there's an easy fix to just move to v4.13.1.