### PR TITLE
Move everything to latest fabric-protos (v0.3.3).

### DIFF
--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.hyperledger.fabric</groupId>
 			<artifactId>fabric-protos</artifactId>
-			<version>0.1.3</version>
+			<version>0.3.3</version>
 			<scope>compile</scope>
 		</dependency>
 

--- a/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
-    implementation 'org.hyperledger.fabric:fabric-protos:0.2.+'
+    implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 
 shadowJar {

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
-    implementation 'org.hyperledger.fabric:fabric-protos:0.2.+'
+    implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 
 shadowJar {

--- a/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
-    implementation 'org.hyperledger.fabric:fabric-protos:0.2.+'
+    implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.google.code.gson:gson:2.10.1'
 }

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -50,7 +50,7 @@ tasks.withType(org.gradle.api.tasks.testing.Test) {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric:fabric-protos:0.2.1'
+    implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.77'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
     implementation 'io.github.classgraph:classgraph:4.8.165'


### PR DESCRIPTION
The latest `fabic-protos` release is v0.3.3. I expect that all of our tests may fail using this version of the package, but I want to see where exactly the problem lies.