### PR TITLE
Upgrade the version of JUnit vintage gradle used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
         testImplementation 'com.github.stefanbirkner:system-rules:system-rules-1.17.0'
 
         testCompileOnly 'junit:junit:4.13.2'
-        testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.3.1'
+        testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.10.2'
         testImplementation 'org.assertj:assertj-core:3.9.1'
     }
 

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/InvocationTaskManager.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/InvocationTaskManager.java
@@ -142,11 +142,10 @@ public final class InvocationTaskManager {
      * @param chaincodeMessage ChaincodeMessage
      */
     public void onChaincodeMessage(final ChaincodeMessage chaincodeMessage) throws IllegalArgumentException {
-        logger.fine(() -> String.format("[%-8.8s] %s", chaincodeMessage.getTxid(), ChaincodeBase.toJsonString(chaincodeMessage)));
         if (chaincodeMessage == null) {
             throw new IllegalArgumentException("chaincodeMessage is null");
         }
-
+        logger.fine(() -> String.format("[%-8.8s] %s", chaincodeMessage.getTxid(), ChaincodeBase.toJsonString(chaincodeMessage)));
         try {
             final Type msgType = chaincodeMessage.getType();
             switch (chaincode.getState()) {


### PR DESCRIPTION
Again for CVE-2020-15250.


testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.1' imports `junit:junit:4.12`... gotta move to `org.junit.vintage:junit-vintage-engine:5.10.2` to get to `junit:junit:4.13.2`.