### PR TITLE
Avoid deprecated usage of Docker action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-          config-inline: |
+          buildkitd-config-inline: |
             [worker.oci]
               max-parallelism = 1
       - name: Login to the ${{ matrix.DOCKER_REGISTRY }} Container Registry
@@ -97,7 +97,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
-      - name: Build and push ${{ matrix.COMPONENT }} Image
+      - name: Build and push image
         id: push
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
The `config-inline` option for docker/setup-buildx-action is replaced by `buildkitd-config-inline`.