### PR TITLE
Update Docker base image version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           - publishAllPublicationsToReleaseRepository
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 apply plugin: 'idea'
 apply plugin: 'eclipse-wtp'
-version = '2.5.1'
+version = '2.5.2'
 
 
 // If the nightly property is set, then this is the scheduled main 

--- a/examples/fabric-contract-example-as-service/build.gradle
+++ b/examples/fabric-contract-example-as-service/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
     compile 'org.json:json:20231013'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
+++ b/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
@@ -19,7 +19,7 @@ java {
 
 
 dependencies {
-    implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1")
+    implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2")
     implementation("org.json:json:20231013")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
            

--- a/examples/fabric-contract-example-gradle/build.gradle
+++ b/examples/fabric-contract-example-gradle/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
     compile 'org.json:json:20231013'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.2</fabric-chaincode-java.version>
 
 		<!-- Logging -->
 		<logback.version>1.3.14</logback.version>

--- a/examples/ledger-api/build.gradle
+++ b/examples/ledger-api/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
     compile 'org.json:json:20231013'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/fabric-chaincode-docker/Dockerfile
+++ b/fabric-chaincode-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.22_7-jdk as builder
+FROM eclipse-temurin:11-jdk as builder
 ENV DEBIAN_FRONTEND=noninteractive 
 
 # Build tools
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-c"]
 RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install gradle 8.6
 RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install maven 3.9.6
 
-FROM eclipse-temurin:11.0.22_7-jdk as dependencies
+FROM eclipse-temurin:11-jdk as dependencies
 
 COPY --from=builder /root/.sdkman/candidates/gradle/current /usr/bin/gradle
 COPY --from=builder /root/.sdkman/candidates/maven/current /usr/bin/maven
@@ -53,20 +53,19 @@ RUN mvn -N io.takari:maven:wrapper
 
 # Creating final javaenv image which will include all required
 # dependencies to build and compile java chaincode
-FROM eclipse-temurin:11.0.22_7-jdk
+FROM eclipse-temurin:11-jdk
 
 RUN apt-get update \
     && apt-get -y install zip unzip \       
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /chaincode/input \
+    && mkdir -p /chaincode/output
 
 SHELL ["/bin/bash", "-c"]
 
 # Copy setup scripts, and the cached dependeices
 COPY --from=dependencies /root/chaincode-java /root/chaincode-java
 COPY --from=dependencies /root/.m2 /root/.m2
-
-RUN mkdir -p /chaincode/input
-RUN mkdir -p /chaincode/output
 
 WORKDIR /root/chaincode-java

--- a/fabric-chaincode-docker/build.gradle
+++ b/fabric-chaincode-docker/build.gradle
@@ -66,6 +66,6 @@ task copyAllDeps(type: Copy) {
 task buildImage(type: DockerBuildImage) {
     dependsOn copyAllDeps
     inputDir = project.file('Dockerfile').parentFile
-    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.1', 'hyperledger/fabric-javaenv:amd64-latest']
+    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.2', 'hyperledger/fabric-javaenv:amd64-latest']
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -51,8 +51,8 @@ tasks.withType(org.gradle.api.tasks.testing.Test) {
 
 dependencies {
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
     implementation 'io.github.classgraph:classgraph:4.8.165'
     implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.4'
     implementation 'org.json:json:20240303'


### PR DESCRIPTION
Use latest eclipse-termurin:11-jdk image to minimise exposure to security vulnerabilities in the base image.

Also:
- Change permissions for Gradle publishing workflow to allow publish to GitHub Packages.
- Update Bouncy Castle dependency to latest patch release (1.78 to 1.78.1).