### PR TITLE
Move to com.github.erosb:json-sKema:0.15.0 

### DIFF
--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
     implementation 'io.github.classgraph:classgraph:4.8.165'
-    implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.4'
+    implementation("com.github.erosb:json-sKema:0.15.0")
     implementation 'org.json:json:20240303'
     implementation 'com.google.protobuf:protobuf-java-util:3.24.4'
     

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/MetadataBuilderTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/MetadataBuilderTest.java
@@ -9,9 +9,10 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.net.URI;
 
-import org.everit.json.schema.loader.SchemaClient;
-import org.everit.json.schema.loader.internal.DefaultSchemaClient;
+import com.github.erosb.jsonsKema.SchemaClient;
+import com.github.erosb.jsonsKema.JsonValue;
 import org.hyperledger.fabric.contract.ChaincodeStubNaiveImpl;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.routing.ContractDefinition;
@@ -58,8 +59,6 @@ public class MetadataBuilderTest {
         setMetadataBuilderField("componentMap", new HashMap<String, Object>());
         setMetadataBuilderField("contractMap", new HashMap<String, HashMap<String, Serializable>>());
         setMetadataBuilderField("overallInfoMap", new HashMap<String, Object>());
-        setMetadataBuilderField("schemaClient", new DefaultSchemaClient());
-
     }
 
     @Test
@@ -77,8 +76,13 @@ public class MetadataBuilderTest {
         setMetadataBuilderField("schemaClient", new SchemaClient() {
 
             @Override
-            public InputStream get(final String uri) {
+            public InputStream get(final URI uri) {
                 throw new RuntimeException("Refusing to load schema: " + uri);
+            }
+
+            @Override
+            public JsonValue getParsed(final URI uri) {
+                throw new RuntimeException("Refusing to load and parse schema: " + uri);
             }
 
         });


### PR DESCRIPTION
`org.everit.erosb` is deprecated. See https://github.com/everit-org/json-schema?tab=readme-ov-file#deprecation-notice.  So there's a new schema, and also there are dependencies in the erosb fork that aren't going to be maintained, etc.