### PR TITLE
Update shim version in integration test chaincodes

### DIFF
--- a/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.2</fabric-chaincode-java.version>
 
 	</properties>
 	

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.google.code.gson:gson:2.10.1'

--- a/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.2</fabric-chaincode-java.version>
 
 	</properties>
 	


### PR DESCRIPTION
Now that we have a new Shim version 2.5.2, there's a couple of other examples that can point to it.