### PR TITLE
Restore Java 8 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
         ref: ${{ inputs.checkout-ref }}
     - uses: actions/setup-java@v4
       with:
-        distribution: 'temurin'
-        java-version: '11'
+        distribution: temurin
+        java-version: 11
     - name: Validate Gradle wrapper
       uses: gradle/actions/wrapper-validation@v3
     - uses: gradle/actions/setup-gradle@v3
@@ -37,8 +37,8 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: temurin
+          java-version: 11
       - name: Populate chaincode with latest java-version
         run: |
           ./gradlew -I $GITHUB_WORKSPACE/fabric-chaincode-integration-test/chaincodebootstrap.gradle -PchaincodeRepoDir=$GITHUB_WORKSPACE/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/repository publishShimPublicationToFabricRepository
@@ -70,8 +70,8 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: temurin
+          java-version: 11
       - uses: gradle/actions/setup-gradle@v3
       - name: Build Docker image
         run: ./gradlew :fabric-chaincode-docker:buildImage

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Make sure you have the following prereqs installed:
 
 - [Docker](https://www.docker.com/get-docker)
 - [Docker Compose](https://docs.docker.com/compose/install/)
-- [JDK 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
+- [JDK 11](https://adoptium.net/)
 
 > **Note:** Java can be installed using [sdkman](https://sdkman.io/).
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 apply plugin: 'idea'
 apply plugin: 'eclipse-wtp'
-version = '2.5.2'
+version = '2.5.3'
 
 
 // If the nightly property is set, then this is the scheduled main 
@@ -23,8 +23,6 @@ if (properties.containsKey('NIGHTLY')) {
 allprojects {
     repositories {
         mavenCentral()
-        mavenLocal()
-        jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://www.jitpack.io" }
     }
@@ -38,8 +36,12 @@ subprojects {
     version = rootProject.version
 
     java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(11)
+        sourceCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    compileJava {
+        if (javaCompiler.get().metadata.languageVersion.canCompileOrRun(10)) {
+            options.release = 8
         }
     }
 

--- a/examples/fabric-contract-example-as-service/build.gradle
+++ b/examples/fabric-contract-example-as-service/build.gradle
@@ -10,7 +10,6 @@ tasks.compileJava {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url "https://www.jitpack.io"

--- a/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
+++ b/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
@@ -13,11 +13,6 @@ plugins {
 
 version = "0.0.1"
 
-java {
- sourceCompatibility = JavaVersion.VERSION_1_8
-}
-
-
 dependencies {
     implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2")
     implementation("org.json:json:20231013")
@@ -28,9 +23,7 @@ dependencies {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
-    jcenter()
     maven {
         setUrl("https://jitpack.io")
     }

--- a/examples/fabric-contract-example-gradle/build.gradle
+++ b/examples/fabric-contract-example-gradle/build.gradle
@@ -10,7 +10,6 @@ tasks.compileJava {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url "https://www.jitpack.io"

--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.2</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.3</fabric-chaincode-java.version>
 
 		<!-- Logging -->
 		<logback.version>1.3.14</logback.version>

--- a/examples/ledger-api/build.gradle
+++ b/examples/ledger-api/build.gradle
@@ -10,7 +10,6 @@ tasks.compileJava {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url "https://www.jitpack.io"

--- a/fabric-chaincode-docker/Dockerfile
+++ b/fabric-chaincode-docker/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update \
 
 SHELL ["/bin/bash", "-c"]
 
-# Copy setup scripts, and the cached dependeices
+# Copy setup scripts, and the cached dependencies
 COPY --from=dependencies /root/chaincode-java /root/chaincode-java
 COPY --from=dependencies /root/.m2 /root/.m2
 

--- a/fabric-chaincode-docker/build.gradle
+++ b/fabric-chaincode-docker/build.gradle
@@ -6,8 +6,6 @@
 
 buildscript {
     repositories {
-        mavenLocal()
-        jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://www.jitpack.io" }
         mavenCentral()
@@ -66,6 +64,6 @@ task copyAllDeps(type: Copy) {
 task buildImage(type: DockerBuildImage) {
     dependsOn copyAllDeps
     inputDir = project.file('Dockerfile').parentFile
-    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.2', 'hyperledger/fabric-javaenv:amd64-latest']
+    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.3', 'hyperledger/fabric-javaenv:amd64-latest']
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
@@ -6,12 +6,11 @@ plugins {
 group 'org.hyperledger.fabric-chaincode-java'
 version '1.0-SNAPSHOT'
 
-tasks.compileJava {
-    sourceCompatibility = '1.8'
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "https://www.jitpack.io" }
     maven {
@@ -20,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.3'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.3</fabric-chaincode-java.version>
 
 	</properties>
 	

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
@@ -6,12 +6,17 @@ plugins {
 group 'org.hyperledger.fabric-chaincode-java'
 version '1.0-SNAPSHOT'
 
-tasks.compileJava {
-    options.release.set(8)
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+compileJava {
+    if (javaCompiler.get().metadata.languageVersion.canCompileOrRun(10)) {
+        options.release = 8
+    }
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "https://www.jitpack.io" }
     maven {
@@ -20,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.3'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
@@ -6,8 +6,14 @@ plugins {
 group 'org.hyperledger.fabric-chaincode-java'
 version '1.0-SNAPSHOT'
 
-tasks.compileJava {
-    options.release.set(8)
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+compileJava {
+    if (javaCompiler.get().metadata.languageVersion.canCompileOrRun(10)) {
+        options.release = 8
+    }
 }
 
 repositories {
@@ -19,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.3'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.google.code.gson:gson:2.10.1'

--- a/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.1</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.3</fabric-chaincode-java.version>
 
 	</properties>
 	


### PR DESCRIPTION
Build with source and target bytecode compatibility for Java 8. This allows chaincode implementation code that requires Java 8 compatibility to compile against the fabric-chaincode-shim package.

Avoid use of mavenLocal() and (deprecated) jcenter() Gradle repositories.