### PR TITLE
Use Gradle lockfile instead of CycloneDX SBOM for scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ repository
 .gradle
 /build/
 out/
+gradle.lockfile
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@
 .PHONEY: scan
 scan:
 	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-	./gradlew cyclonedxBom
-	osv-scanner --sbom='fabric-chaincode-shim/build/reports/bom.json'
+	./gradlew --quiet resolveAndLockAll --write-locks
+	osv-scanner scan --lockfile=fabric-chaincode-shim/gradle.lockfile

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -33,16 +33,20 @@ checkstyleTest {
     source ='src/test/java'
 }
 
-cyclonedxBom {
-    includeConfigs = ["runtimeClasspath"]
-    skipConfigs = ["compileClasspath", "testCompileClasspath"]
-    projectType = "library"
-    schemaVersion = "1.5"
-    destination = file("build/reports")
-    outputName = "bom"
-    outputFormat = "json"
-    includeBomSerialNumber = false
-    includeLicenseText = false
+configurations {
+    runtimeClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
+tasks.register('resolveAndLockAll') {
+    notCompatibleWithConfigurationCache("Filters configurations at execution time")
+    doFirst {
+        assert gradle.startParameter.writeDependencyLocks : "$path must be run from the command line with the `--write-locks` flag"
+    }
+    doLast {
+        configurations.findAll { it.canBeResolved }.each { it.resolve() }
+    }
 }
 
 tasks.withType(org.gradle.api.tasks.testing.Test) {


### PR DESCRIPTION
A CycloneDX SBOM was generated to allow OSV-Scanner to scan all transitive dependencies. A similar result can be achieved using Gradle lockfiles, removing the need to use CycloneDX.