### PR TITLE
Update dependencies to address CVE-2024-7254

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-apply plugin: 'idea'
-apply plugin: 'eclipse-wtp'
+plugins {
+    id "com.github.ben-manes.versions" version "0.51.0"
+}
+
 version = '2.5.3'
 
 
@@ -46,18 +48,16 @@ subprojects {
     }
 
     dependencies {
-        implementation 'commons-cli:commons-cli:1.6.0'
-        implementation 'commons-logging:commons-logging:1.2'
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+        implementation 'commons-cli:commons-cli:1.9.0'
+        implementation 'commons-logging:commons-logging:1.3.4'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.0'
 
-        testImplementation 'org.hamcrest:hamcrest-library:1.3'
-        testImplementation 'org.mockito:mockito-core:2.23.0'
-        testImplementation 'com.github.stefanbirkner:system-rules:system-rules-1.17.0'
+        testImplementation 'org.hamcrest:hamcrest-library:3.0'
+        testImplementation 'org.mockito:mockito-core:5.13.0'
+        testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.6'
 
-        testCompileOnly 'junit:junit:4.13.2'
-        testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.10.2'
-        testImplementation 'org.assertj:assertj-core:3.9.1'
+        testImplementation 'org.assertj:assertj-core:3.26.3'
     }
 
     test {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id "com.github.ben-manes.versions" version "0.51.0"
 }
 
-version = '2.5.3'
+version = '2.5.4'
 
 
 // If the nightly property is set, then this is the scheduled main 

--- a/examples/fabric-contract-example-as-service/build.gradle
+++ b/examples/fabric-contract-example-as-service/build.gradle
@@ -22,10 +22,10 @@ repositories {
 
 dependencies {
     compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
-    compile 'org.json:json:20231013'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:2.+'
+    compile 'org.json:json:20240303'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.mockito:mockito-core:5.13.0'
 }
 
 shadowJar {

--- a/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
+++ b/examples/fabric-contract-example-gradle-kotlin/build.gradle.kts
@@ -15,10 +15,10 @@ version = "0.0.1"
 
 dependencies {
     implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2")
-    implementation("org.json:json:20231013")
+    implementation("org.json:json:20240303")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
            
-    testImplementation("org.junit.jupiter:junit-jupiter:5.4.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0")
 }
 

--- a/examples/fabric-contract-example-gradle/build.gradle
+++ b/examples/fabric-contract-example-gradle/build.gradle
@@ -22,10 +22,10 @@ repositories {
 
 dependencies {
     compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
-    compile 'org.json:json:20231013'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:2.+'
+    compile 'org.json:json:20240303'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.mockito:mockito-core:5.13.0'
 }
 
 shadowJar {

--- a/examples/ledger-api/build.gradle
+++ b/examples/ledger-api/build.gradle
@@ -22,10 +22,10 @@ repositories {
 
 dependencies {
     compile 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.2'
-    compile 'org.json:json:20231013'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:2.+'
+    compile 'org.json:json:20240303'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.mockito:mockito-core:5.13.0'
 }
 
 shadowJar {

--- a/fabric-chaincode-docker/build.gradle
+++ b/fabric-chaincode-docker/build.gradle
@@ -9,9 +9,10 @@ buildscript {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://www.jitpack.io" }
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.bmuschko:gradle-docker-plugin:5.1.0'
+        classpath 'com.bmuschko:gradle-docker-plugin:9.4.0'
     }
 }
 
@@ -64,6 +65,6 @@ task copyAllDeps(type: Copy) {
 task buildImage(type: DockerBuildImage) {
     dependsOn copyAllDeps
     inputDir = project.file('Dockerfile').parentFile
-    tags = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.3', 'hyperledger/fabric-javaenv:amd64-latest']
+    images = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.3', 'hyperledger/fabric-javaenv:amd64-latest']
 }
 

--- a/fabric-chaincode-docker/build.gradle
+++ b/fabric-chaincode-docker/build.gradle
@@ -65,6 +65,6 @@ task copyAllDeps(type: Copy) {
 task buildImage(type: DockerBuildImage) {
     dependsOn copyAllDeps
     inputDir = project.file('Dockerfile').parentFile
-    images = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.3', 'hyperledger/fabric-javaenv:amd64-latest']
+    images = ['hyperledger/fabric-javaenv', 'hyperledger/fabric-javaenv:2.5', 'hyperledger/fabric-javaenv:amd64-2.5.4', 'hyperledger/fabric-javaenv:amd64-latest']
 }
 

--- a/fabric-chaincode-integration-test/build.gradle
+++ b/fabric-chaincode-integration-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation project(':fabric-chaincode-docker')
     implementation project(':fabric-chaincode-shim')
-    implementation 'org.json:json:20231013'
+    implementation 'org.json:json:20240303'
 }
 
 

--- a/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.3'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.4'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/bare-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.3</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.4</fabric-chaincode-java.version>
 
 	</properties>
 	

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.3'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.4'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.3'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.4'
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.google.code.gson:gson:2.10.1'

--- a/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
+++ b/fabric-chaincode-integration-test/src/contracts/wrapper-maven/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.5.3</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>2.5.4</fabric-chaincode-java.version>
 
 	</properties>
 	

--- a/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/contractinstall/ContractInstallTest.java
+++ b/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/contractinstall/ContractInstallTest.java
@@ -4,13 +4,14 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 package org.hyperleder.fabric.shim.integration.contractinstall;
+
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hyperleder.fabric.shim.integration.util.FabricState;
 import org.hyperleder.fabric.shim.integration.util.InvokeHelper;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic Java Chaincode Test
@@ -18,7 +19,7 @@ import org.junit.Test;
  */
 public class ContractInstallTest {
 
-   @BeforeClass
+   @BeforeAll
     public static void setUp() throws Exception {
         FabricState.getState().start();
         

--- a/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/ledgertests/LedgerIntegrationTest.java
+++ b/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/ledgertests/LedgerIntegrationTest.java
@@ -5,12 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 */
 package org.hyperleder.fabric.shim.integration.ledgertests;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hyperleder.fabric.shim.integration.util.FabricState;
 import org.hyperleder.fabric.shim.integration.util.InvokeHelper;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic Java Chaincode Test
@@ -18,7 +18,7 @@ import org.junit.Test;
  */
 public class LedgerIntegrationTest {
 
-   @BeforeClass
+   @BeforeAll
     public static void setUp() throws Exception {
 
 

--- a/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/shimtests/SACCIntegrationTest.java
+++ b/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/shimtests/SACCIntegrationTest.java
@@ -5,12 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 */
 package org.hyperleder.fabric.shim.integration.shimtests;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hyperleder.fabric.shim.integration.util.FabricState;
 import org.hyperleder.fabric.shim.integration.util.InvokeHelper;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic Java Chaincode Test
@@ -18,7 +18,7 @@ import org.junit.Test;
  */
 public class SACCIntegrationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         FabricState.getState().start();       
 

--- a/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/shimtests/SBECCIntegrationTest.java
+++ b/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/shimtests/SBECCIntegrationTest.java
@@ -7,16 +7,16 @@ package org.hyperleder.fabric.shim.integration.shimtests;
 
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.Matchers.not; 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hyperleder.fabric.shim.integration.util.FabricState;
 import org.hyperleder.fabric.shim.integration.util.InvokeHelper;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class SBECCIntegrationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         FabricState.getState().start();
         

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -3,25 +3,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
- buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'org.owasp:dependency-check-gradle:8.4.0'
-    }
-}
 
 plugins {
     id 'maven-publish'
     id 'jacoco'
     id 'signing'
     id 'checkstyle'
-    id 'org.cyclonedx.bom' version '1.8.1'
 }
 
 checkstyle {
-    toolVersion '10.12.5'
+    toolVersion '10.18.1'
     configFile file("../ci/checkstyle/checkstyle.xml")
     configProperties = [root_dir: file("..") ]
 }
@@ -54,34 +45,33 @@ tasks.withType(org.gradle.api.tasks.testing.Test) {
 }
 
 dependencies {
+    implementation platform('com.google.protobuf:protobuf-bom:3.25.5')
+    implementation platform('io.grpc:grpc-bom:1.68.0')
+    implementation platform('io.opentelemetry:opentelemetry-bom:1.42.1')
+
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
     implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
-    implementation 'io.github.classgraph:classgraph:4.8.165'
+    implementation 'io.github.classgraph:classgraph:4.8.176'
     implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.4'
     implementation 'org.json:json:20240303'
-    implementation 'com.google.protobuf:protobuf-java-util:3.24.4'
+    implementation 'com.google.protobuf:protobuf-java-util'
     
-    // Required if using Java 11+ as no longer bundled in the core libraries
-    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
-
-    implementation platform('io.grpc:grpc-bom:1.60.0')
     implementation 'io.grpc:grpc-netty-shaded'
     implementation 'io.grpc:grpc-protobuf'
     implementation 'io.grpc:grpc-stub'
-
     testImplementation 'io.grpc:grpc-inprocess'
-
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.32.0")
+    // Required if using Java 11+ as no longer bundled in the core libraries
+    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
 
     implementation 'io.opentelemetry:opentelemetry-api'
-    implementation 'io.opentelemetry.proto:opentelemetry-proto:1.0.0-alpha'
+    implementation 'io.opentelemetry.proto:opentelemetry-proto:1.3.2-alpha'
     implementation 'io.opentelemetry:opentelemetry-sdk'
     implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
     implementation 'io.opentelemetry:opentelemetry-sdk-trace'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
     implementation 'io.opentelemetry:opentelemetry-extension-trace-propagators'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:1.32.0-alpha'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:2.8.0-alpha'
 }
 
 sourceSets {

--- a/fabric-chaincode-shim/src/test/java/ChaincodeWithoutPackageTest.java
+++ b/fabric-chaincode-shim/src/test/java/ChaincodeWithoutPackageTest.java
@@ -4,31 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static org.hamcrest.Matchers.is;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.READY;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.REGISTER;
-import static org.junit.Assert.assertThat;
+import org.hyperledger.fabric.shim.ChaincodeBase;
+import org.hyperledger.fabric.shim.mock.peer.ChaincodeMockPeer;
+import org.hyperledger.fabric.shim.mock.peer.RegisterStep;
+import org.hyperledger.fabric.shim.mock.peer.ScenarioStep;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.hyperledger.fabric.shim.ChaincodeBase;
-import org.hyperledger.fabric.shim.mock.peer.ChaincodeMockPeer;
-import org.hyperledger.fabric.shim.mock.peer.RegisterStep;
-import org.hyperledger.fabric.shim.mock.peer.ScenarioStep;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.READY;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.REGISTER;
 
 public final class ChaincodeWithoutPackageTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
     private ChaincodeMockPeer server;
 
-    @After
+    @AfterEach
     public void afterTest() throws Exception {
         if (server != null) {
             server.stop();
@@ -49,8 +43,8 @@ public final class ChaincodeWithoutPackageTest {
 
         ChaincodeMockPeer.checkScenarioStepEnded(server, 1, 5000, TimeUnit.MILLISECONDS);
 
-        assertThat(server.getLastMessageSend().getType(), is(READY));
-        assertThat(server.getLastMessageRcvd().getType(), is(REGISTER));
+        assertThat(server.getLastMessageSend().getType()).isEqualTo(READY);
+        assertThat(server.getLastMessageRcvd().getType()).isEqualTo(REGISTER);
     }
 
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggerTest.java
@@ -7,14 +7,9 @@
 package org.hyperledger.fabric;
 
 import org.hyperledger.fabric.contract.ContractRuntimeException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class LoggerTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void logger() {
         Logger.getLogger(LoggerTest.class);

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggingTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/LoggingTest.java
@@ -5,35 +5,30 @@
  */
 package org.hyperledger.fabric;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.logging.Level;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class LoggingTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testMapLevel() {
 
-        assertEquals("Error maps", Level.SEVERE, proxyMapLevel("ERROR"));
-        assertEquals("Critical maps", Level.SEVERE, proxyMapLevel("critical"));
-        assertEquals("Warn maps", Level.WARNING, proxyMapLevel("WARNING"));
-        assertEquals("Info maps", Level.INFO, proxyMapLevel("INFO"));
-        assertEquals("Config maps", Level.CONFIG, proxyMapLevel(" notice"));
-        assertEquals("Info maps", Level.INFO, proxyMapLevel(" info"));
-        assertEquals("Debug maps", Level.FINEST, proxyMapLevel("debug          "));
-        assertEquals("Info maps", Level.INFO, proxyMapLevel("wibble          "));
-        assertEquals("Info maps", Level.INFO, proxyMapLevel(new Object[] {null}));
+        assertEquals(Level.SEVERE, proxyMapLevel("ERROR"), "Error maps");
+        assertEquals(Level.SEVERE, proxyMapLevel("critical"), "Critical maps");
+        assertEquals(Level.WARNING, proxyMapLevel("WARNING"), "Warn maps");
+        assertEquals(Level.INFO, proxyMapLevel("INFO"), "Info maps");
+        assertEquals(Level.CONFIG, proxyMapLevel(" notice"), "Config maps");
+        assertEquals(Level.INFO, proxyMapLevel(" info"), "Info maps");
+        assertEquals(Level.FINEST, proxyMapLevel("debug          "), "Debug maps");
+        assertEquals(Level.INFO, proxyMapLevel("wibble          "), "Info maps");
+        assertEquals(Level.INFO, proxyMapLevel(new Object[] {null}), "Info maps");
     }
 
     public Object proxyMapLevel(final Object... args) {

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ClientIdentityTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ClientIdentityTest.java
@@ -6,22 +6,18 @@
 
 package org.hyperledger.fabric.contract;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.hyperledger.fabric.TestUtil;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 
-import org.hyperledger.fabric.TestUtil;
-import org.hyperledger.fabric.shim.ChaincodeStub;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ClientIdentityTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     /**
      * Test client identity can be created using certificate without attributes
      */
@@ -104,12 +100,12 @@ public class ClientIdentityTest {
      */
     @Test
     public void catchInvalidProtocolBufferException() {
-        thrown.expect(ContractRuntimeException.class);
-        thrown.expectMessage("Could not create new client identity");
-
         final ChaincodeStub stub = mock(ChaincodeStub.class);
         when(stub.getCreator()).thenReturn("somethingInvalid".getBytes());
-        ContextFactory.getInstance().createContext(stub);
+
+        assertThatThrownBy(() -> ContextFactory.getInstance().createContext(stub))
+                .isInstanceOf(ContractRuntimeException.class)
+                .hasMessage("Could not create new client identity");
 
     }
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContextFactoryTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContextFactoryTest.java
@@ -5,15 +5,15 @@
  */
 package org.hyperledger.fabric.contract;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import org.hyperledger.fabric.shim.ChaincodeStub;
-import org.junit.Test;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ContextFactoryTest {
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContextTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContextTest.java
@@ -5,11 +5,11 @@
  */
 package org.hyperledger.fabric.contract;
 
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
-
 import org.hyperledger.fabric.shim.ChaincodeStub;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ContextTest {
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContractInterfaceTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContractInterfaceTest.java
@@ -5,19 +5,15 @@
  */
 package org.hyperledger.fabric.contract;
 
+import org.hyperledger.fabric.shim.ChaincodeException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import org.hyperledger.fabric.shim.ChaincodeException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ContractInterfaceTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void createContext() {
         assertThat((new ContractInterface() {
@@ -26,12 +22,12 @@ public class ContractInterfaceTest {
 
     @Test
     public void unknownTransaction() {
-        thrown.expect(ChaincodeException.class);
-        thrown.expectMessage("Undefined contract method called");
-
         final ContractInterface c = new ContractInterface() {
         };
-        c.unknownTransaction(c.createContext(new ChaincodeStubNaiveImpl()));
+
+        assertThatThrownBy(() -> c.unknownTransaction(c.createContext(new ChaincodeStubNaiveImpl())))
+                .isInstanceOf(ChaincodeException.class)
+                .hasMessage("Undefined contract method called");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContractRouterTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/ContractRouterTest.java
@@ -5,19 +5,7 @@
  */
 package org.hyperledger.fabric.contract;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
-
+import contract.SampleContract;
 import org.hyperledger.fabric.contract.annotation.Contract;
 import org.hyperledger.fabric.contract.execution.ExecutionFactory;
 import org.hyperledger.fabric.contract.execution.InvocationRequest;
@@ -26,23 +14,28 @@ import org.hyperledger.fabric.shim.ChaincodeServer;
 import org.hyperledger.fabric.shim.ChaincodeServerProperties;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 import org.hyperledger.fabric.shim.NettyChaincodeServer;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-import contract.SampleContract;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ContractRouterTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testCreateFailsWithoutValidOptions() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(containsString(
-                "The chaincode id must be specified using either the -i or --i command line options or the CORE_CHAINCODE_ID_NAME environment variable."));
-
-        @SuppressWarnings("unused") final ContractRouter r = new ContractRouter(new String[]{});
+        assertThatThrownBy(() -> new ContractRouter(new String[]{}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The chaincode id must be specified using either the -i or --i command "
+                        + "line options or the CORE_CHAINCODE_ID_NAME environment variable.");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/TransactionExceptionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/TransactionExceptionTest.java
@@ -5,14 +5,12 @@
  */
 package org.hyperledger.fabric.contract;
 
+import org.hyperledger.fabric.shim.ChaincodeException;
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-
-import org.hyperledger.fabric.shim.ChaincodeException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TransactionExceptionTest {
 
@@ -33,9 +31,6 @@ public class TransactionExceptionTest {
             return payload.getBytes();
         }
     }
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testNoArgConstructor() {

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/ContractExecutionServiceTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/ContractExecutionServiceTest.java
@@ -18,11 +18,8 @@ import org.hyperledger.fabric.contract.routing.ParameterDefinition;
 import org.hyperledger.fabric.contract.routing.TxFunction;
 import org.hyperledger.fabric.contract.routing.impl.ParameterDefinitionImpl;
 import org.hyperledger.fabric.contract.routing.impl.SerializerRegistryImpl;
-import org.hyperledger.fabric.shim.Chaincode.Response;
 import org.hyperledger.fabric.shim.ChaincodeStub;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -30,19 +27,14 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ContractExecutionServiceTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @SuppressWarnings({  "serial" })
+public final class ContractExecutionServiceTest {
     @Test
     public void noReturnValue()
             throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException, SecurityException {
@@ -68,7 +60,6 @@ public class ContractExecutionServiceTest {
 
     }
 
-    @SuppressWarnings({ "serial" })
     @Test()
     public void failureToInvoke()
             throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException, SecurityException {
@@ -92,14 +83,11 @@ public class ContractExecutionServiceTest {
         when(routing.toString()).thenReturn("MockMethodName:MockClassName");
         when(serializerRegistry.getSerializer(any(), any())).thenReturn(jts);
 
-        thrown.expect(ContractRuntimeException.class);
-        thrown.expectMessage("Could not execute contract method: MockMethodName:MockClassName");
-
-        Response resp = ces.executeRequest(txFn, req, stub);
-        assertThat(resp.getStatusCode(), equalTo(500));
+        assertThatThrownBy(() -> ces.executeRequest(txFn, req, stub))
+                .isInstanceOf(ContractRuntimeException.class)
+                .hasMessage("Could not execute contract method: MockMethodName:MockClassName");
     }
 
-    @SuppressWarnings({ "serial" })
     @Test()
     public void invokeWithDifferentSerializers()
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/execution/JSONTransactionSerializerTest.java
@@ -7,8 +7,8 @@
 package org.hyperledger.fabric.contract.execution;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 
@@ -18,16 +18,11 @@ import org.hyperledger.fabric.contract.metadata.MetadataBuilder;
 import org.hyperledger.fabric.contract.metadata.TypeSchema;
 import org.hyperledger.fabric.contract.routing.TypeRegistry;
 import org.hyperledger.fabric.contract.routing.impl.TypeRegistryImpl;
-import org.junit.Rule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 
 public class JSONTransactionSerializerTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void toBuffer() {
         final TypeRegistry tr = TypeRegistry.getRegistry();

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/MetadataBuilderTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/MetadataBuilderTest.java
@@ -5,11 +5,7 @@
  */
 package org.hyperledger.fabric.contract.metadata;
 
-import java.io.InputStream;
-import java.io.Serializable;
-import java.lang.reflect.Field;
-import java.util.HashMap;
-
+import contract.SampleContract;
 import org.everit.json.schema.loader.SchemaClient;
 import org.everit.json.schema.loader.internal.DefaultSchemaClient;
 import org.hyperledger.fabric.contract.ChaincodeStubNaiveImpl;
@@ -18,18 +14,16 @@ import org.hyperledger.fabric.contract.routing.ContractDefinition;
 import org.hyperledger.fabric.contract.routing.impl.ContractDefinitionImpl;
 import org.hyperledger.fabric.contract.systemcontract.SystemContract;
 import org.hyperledger.fabric.shim.ChaincodeStub;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import contract.SampleContract;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.HashMap;
 
-public class MetadataBuilderTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
+public final class MetadataBuilderTest {
     private final String expectedMetadataString = "    {\n" + "       \"components\": {\"schemas\": {}},\n"
             + "       \"$schema\": \"https://fabric-shim.github.io/contract-schema.json\",\n" + "       \"contracts\": {\"SampleContract\": {\n"
             + "          \"name\": \"SampleContract\",\n" + "          \"transactions\": [],\n" + "          \"info\": {\n"
@@ -51,8 +45,8 @@ public class MetadataBuilderTest {
         }
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void beforeAndAfterEach() {
 
         setMetadataBuilderField("componentMap", new HashMap<String, Object>());

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/TypeSchemaTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/metadata/TypeSchemaTest.java
@@ -6,7 +6,7 @@
 package org.hyperledger.fabric.contract.metadata;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.hyperledger.fabric.contract.annotation.DataType;
@@ -15,12 +15,12 @@ import org.hyperledger.fabric.contract.routing.TypeRegistry;
 import org.hyperledger.fabric.contract.routing.impl.DataTypeDefinitionImpl;
 import org.hyperledger.fabric.contract.routing.impl.TypeRegistryImpl;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TypeSchemaTest {
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
     }
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/ContractDefinitionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/ContractDefinitionTest.java
@@ -5,34 +5,24 @@
  */
 package org.hyperledger.fabric.contract.routing;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-
-import java.lang.reflect.Method;
-import java.security.Permission;
-
+import contract.SampleContract;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.ContractInterface;
 import org.hyperledger.fabric.contract.ContractRuntimeException;
 import org.hyperledger.fabric.contract.annotation.Contract;
 import org.hyperledger.fabric.contract.annotation.Info;
 import org.hyperledger.fabric.contract.routing.impl.ContractDefinitionImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-import contract.SampleContract;
+import java.lang.reflect.Method;
+import java.security.Permission;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 
 public class ContractDefinitionTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
-    public void beforeEach() {
-    }
-
     @Test
     public void constructor() throws NoSuchMethodException, SecurityException {
 
@@ -92,10 +82,9 @@ public class ContractDefinitionTest {
         final ContractInterface contract = new SampleContract();
         final Method m = contract.getClass().getMethod("t2", new Class<?>[] {Context.class});
 
-        thrown.expect(ContractRuntimeException.class);
-        thrown.expectMessage("Duplicate transaction method t2");
-
         cf.addTxFunction(m);
-        cf.addTxFunction(m);
+        assertThatThrownBy(() -> cf.addTxFunction(m))
+                .isInstanceOf(ContractRuntimeException.class)
+                .hasMessage("Duplicate transaction method t2");
     }
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/DataTypeDefinitionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/DataTypeDefinitionTest.java
@@ -5,28 +5,18 @@
  */
 package org.hyperledger.fabric.contract.routing;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
-import static org.junit.Assert.assertThat;
+import org.hyperledger.fabric.contract.MyType2;
+import org.hyperledger.fabric.contract.routing.impl.DataTypeDefinitionImpl;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import org.hyperledger.fabric.contract.MyType2;
-import org.hyperledger.fabric.contract.routing.impl.DataTypeDefinitionImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 
 public class DataTypeDefinitionTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
-    public void beforeEach() {
-    }
-
     @Test
     public void constructor() {
         final DataTypeDefinitionImpl dtd = new DataTypeDefinitionImpl(MyType2.class);

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/ParameterDefinitionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/ParameterDefinitionTest.java
@@ -5,26 +5,16 @@
  */
 package org.hyperledger.fabric.contract.routing;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.hyperledger.fabric.contract.metadata.TypeSchema;
+import org.hyperledger.fabric.contract.routing.impl.ParameterDefinitionImpl;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Parameter;
 
-import org.hyperledger.fabric.contract.metadata.TypeSchema;
-import org.hyperledger.fabric.contract.routing.impl.ParameterDefinitionImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 public class ParameterDefinitionTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
-    public void beforeEach() {
-    }
-
     @Test
     public void constructor() throws NoSuchMethodException, SecurityException {
         final Parameter[] params = String.class.getMethod("concat", String.class).getParameters();

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/PropertyDefinitionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/PropertyDefinitionTest.java
@@ -5,26 +5,16 @@
  */
 package org.hyperledger.fabric.contract.routing;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.hyperledger.fabric.contract.metadata.TypeSchema;
+import org.hyperledger.fabric.contract.routing.impl.PropertyDefinitionImpl;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 
-import org.hyperledger.fabric.contract.metadata.TypeSchema;
-import org.hyperledger.fabric.contract.routing.impl.PropertyDefinitionImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 public class PropertyDefinitionTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
-    public void beforeEach() {
-    }
-
     @Test
     public void constructor() throws NoSuchMethodException, SecurityException {
         final Field[] props = String.class.getFields();

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/TxFunctionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/TxFunctionTest.java
@@ -5,13 +5,6 @@
  */
 package org.hyperledger.fabric.contract.routing;
 
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.ContractInterface;
 import org.hyperledger.fabric.contract.ContractRuntimeException;
@@ -20,16 +13,18 @@ import org.hyperledger.fabric.contract.annotation.Property;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 import org.hyperledger.fabric.contract.metadata.TypeSchema;
 import org.hyperledger.fabric.contract.routing.impl.TxFunctionImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TxFunctionTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+public class TxFunctionTest {
     @Contract()
     class TestObject implements ContractInterface {
 
@@ -47,10 +42,6 @@ public class TxFunctionTest {
         public void wibble(final String arg1) {
 
         }
-    }
-
-    @Before
-    public void beforeEach() {
     }
 
     @Test
@@ -93,9 +84,9 @@ public class TxFunctionTest {
         final TestObject test = new TestObject();
         final ContractDefinition cd = mock(ContractDefinition.class);
         Mockito.when(cd.getAnnotation()).thenReturn(test.getClass().getAnnotation(Contract.class));
-        thrown.expect(ContractRuntimeException.class);
-        new TxFunctionImpl(test.getClass().getMethod("wibble", String.class), cd);
 
+        assertThatThrownBy(() -> new TxFunctionImpl(test.getClass().getMethod("wibble", String.class), cd))
+                .isInstanceOf(ContractRuntimeException.class);
     }
 
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/TypeRegistryTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/TypeRegistryTest.java
@@ -5,26 +5,16 @@
  */
 package org.hyperledger.fabric.contract.routing;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.hyperledger.fabric.contract.routing.impl.DataTypeDefinitionImpl;
+import org.hyperledger.fabric.contract.routing.impl.TypeRegistryImpl;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
-import org.hyperledger.fabric.contract.routing.impl.DataTypeDefinitionImpl;
-import org.hyperledger.fabric.contract.routing.impl.TypeRegistryImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 public class TypeRegistryTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
-    public void beforeEach() {
-    }
-
     @Test
     public void addDataType() {
         final TypeRegistryImpl tr = new TypeRegistryImpl();

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/simplepath/ContractSimplePathTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/simplepath/ContractSimplePathTest.java
@@ -5,16 +5,7 @@
  */
 package org.hyperledger.fabric.contract.simplepath;
 
-import static org.hamcrest.Matchers.is;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.READY;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.REGISTER;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.TRANSACTION;
-import static org.junit.Assert.assertThat;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import com.google.protobuf.ByteString;
 import org.hyperledger.fabric.contract.ContractRouter;
 import org.hyperledger.fabric.protos.peer.ChaincodeInput;
 import org.hyperledger.fabric.protos.peer.ChaincodeInput.Builder;
@@ -24,24 +15,30 @@ import org.hyperledger.fabric.shim.mock.peer.ChaincodeMockPeer;
 import org.hyperledger.fabric.shim.mock.peer.RegisterStep;
 import org.hyperledger.fabric.shim.mock.peer.ScenarioStep;
 import org.hyperledger.fabric.shim.utils.MessageUtil;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-public final class ContractSimplePath {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.READY;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.REGISTER;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.TRANSACTION;
 
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+@ExtendWith(SystemStubsExtension.class)
+public final class ContractSimplePathTest {
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     private ChaincodeMockPeer server;
 
-    @After
+    @AfterEach
     public void afterTest() throws Exception {
         if (server != null) {
             server.stop();
@@ -65,8 +62,8 @@ public final class ContractSimplePath {
 
         ChaincodeMockPeer.checkScenarioStepEnded(server, 1, 5000, TimeUnit.MILLISECONDS);
 
-        assertThat(server.getLastMessageSend().getType(), is(READY));
-        assertThat(server.getLastMessageRcvd().getType(), is(REGISTER));
+        assertThat(server.getLastMessageSend().getType()).isEqualTo(READY);
+        assertThat(server.getLastMessageRcvd().getType()).isEqualTo(REGISTER);
         setLogLevel("INFO");
     }
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeBaseTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeBaseTest.java
@@ -6,137 +6,128 @@
 
 package org.hyperledger.fabric.shim;
 
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.logging.Handler;
-import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import org.hamcrest.Matchers;
 import org.hyperledger.fabric.metrics.Metrics;
 import org.hyperledger.fabric.protos.peer.ChaincodeMessage;
 import org.hyperledger.fabric.shim.chaincode.EmptyChaincode;
 import org.hyperledger.fabric.traces.Traces;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import io.grpc.ManagedChannelBuilder;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Properties;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(SystemStubsExtension.class)
 public class ChaincodeBaseTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Test
     public void testNewSuccessResponseEmpty() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newSuccessResponse();
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
-        assertNull("Response message in not null", response.getMessage());
-        assertNull("Response payload in not null", response.getPayload());
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
+        assertThat(response.getMessage()).as("Response message").isNull();
+        assertThat(response.getPayload()).as("Response payload").isNull();
     }
 
     @Test
     public void testNewSuccessResponseWithMessage() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newSuccessResponse("Simple message");
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
-        assertEquals("Response message in not correct", "Simple message", response.getMessage());
-        assertNull("Response payload in not null", response.getPayload());
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
+        assertThat(response.getMessage()).as("Response message").isEqualTo("Simple message");
+        assertThat(response.getPayload()).as("Response payload").isNull();
     }
 
     @Test
     public void testNewSuccessResponseWithPayload() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newSuccessResponse("Simple payload".getBytes(Charset.defaultCharset()));
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
-        assertNull("Response message in not null", response.getMessage());
-        assertArrayEquals("Response payload in not null", response.getPayload(), "Simple payload".getBytes(Charset.defaultCharset()));
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
+        assertThat(response.getMessage()).as("Response message").isNull();
+        assertThat(response.getPayload()).as("Response payload").isEqualTo("Simple payload".getBytes(Charset.defaultCharset()));
     }
 
     @Test
     public void testNewSuccessResponseWithMessageAndPayload() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newSuccessResponse("Simple message",
                 "Simple payload".getBytes(Charset.defaultCharset()));
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
-        assertEquals("Response message in not correct", "Simple message", response.getMessage());
-        assertArrayEquals("Response payload in not null", response.getPayload(), "Simple payload".getBytes(Charset.defaultCharset()));
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.SUCCESS);
+        assertThat(response.getMessage()).as("Response message").isEqualTo("Simple message");
+        assertThat(response.getPayload()).as("Response payload").isEqualTo("Simple payload".getBytes(Charset.defaultCharset()));
     }
 
     @Test
     public void testNewErrorResponseEmpty() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newErrorResponse();
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
-        assertNull("Response message in not null", response.getMessage());
-        assertNull("Response payload in not null", response.getPayload());
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
+        assertThat(response.getMessage()).as("Response message").isNull();
+        assertThat(response.getPayload()).as("Response payload").isNull();
     }
 
     @Test
     public void testNewErrorResponseWithMessage() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newErrorResponse("Simple message");
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
-        assertEquals("Response message in not correct", "Simple message", response.getMessage());
-        assertNull("Response payload in not null", response.getPayload());
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
+        assertThat(response.getMessage()).as("Response message").isEqualTo("Simple message");
+        assertThat(response.getPayload()).as("Response payload").isNull();
     }
 
     @Test
     public void testNewErrorResponseWithPayload() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newErrorResponse("Simple payload".getBytes(Charset.defaultCharset()));
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
-        assertNull("Response message in not null", response.getMessage());
-        assertArrayEquals("Response payload in not null", response.getPayload(), "Simple payload".getBytes(Charset.defaultCharset()));
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
+        assertThat(response.getMessage()).as("Response message").isNull();
+        assertThat(response.getPayload()).as("Response payload").isEqualTo("Simple payload".getBytes(Charset.defaultCharset()));
     }
 
     @Test
     public void testNewErrorResponseWithMessageAndPayload() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newErrorResponse("Simple message",
                 "Simple payload".getBytes(Charset.defaultCharset()));
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
-        assertEquals("Response message in not correct", "Simple message", response.getMessage());
-        assertArrayEquals("Response payload in not null", response.getPayload(), "Simple payload".getBytes(Charset.defaultCharset()));
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
+        assertThat(response.getMessage()).as("Response message").isEqualTo("Simple message");
+        assertThat(response.getPayload()).as("Response payload").isEqualTo("Simple payload".getBytes(Charset.defaultCharset()));
     }
 
     @Test
     public void testNewErrorResponseWithException() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newErrorResponse(new Exception("Simple exception"));
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
-        assertEquals("Response message is not correct", "Unexpected error", response.getMessage());
-        assertNull("Response payload is not null", response.getPayload());
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
+        assertThat(response.getMessage()).as("Response message").isEqualTo("Unexpected error");
+        assertThat(response.getPayload()).as("Response payload").isNull();
     }
 
     @Test
     public void testNewErrorResponseWithChaincodeException() {
         final org.hyperledger.fabric.shim.Chaincode.Response response = ResponseUtils.newErrorResponse(new ChaincodeException("Chaincode exception"));
-        assertEquals("Response status is incorrect", response.getStatus(), org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
-        assertEquals("Response message is not correct", "Chaincode exception", response.getMessage());
-        assertNull("Response payload is not null", response.getPayload());
+        assertThat(response.getStatus()).as("Response status").isEqualTo(org.hyperledger.fabric.shim.Chaincode.Response.Status.INTERNAL_SERVER_ERROR);
+        assertThat(response.getMessage()).as("Response message").isEqualTo("Chaincode exception");
+        assertThat(response.getPayload()).as("Response payload").isNull();
     }
 
     @Test
     public void testOptions() throws Exception {
         final ChaincodeBase cb = new EmptyChaincode();
 
-        assertEquals("Host incorrect", ChaincodeBase.DEFAULT_HOST, cb.getHost());
-        assertEquals("Port incorrect", ChaincodeBase.DEFAULT_PORT, cb.getPort());
-        assertFalse("TLS should not be enabled", cb.isTlsEnabled());
+        assertThat(cb.getHost()).as("Host incorrect").isEqualTo(ChaincodeBase.DEFAULT_HOST);
+        assertThat(cb.getPort()).as("Port incorrect").isEqualTo(ChaincodeBase.DEFAULT_PORT);
+        assertThat(cb.isTlsEnabled()).as("TLS should not be enabled").isFalse();
 
         environmentVariables.set("CORE_CHAINCODE_ID_NAME", "mycc");
         environmentVariables.set("CORE_PEER_ADDRESS", "localhost:7052");
@@ -145,47 +136,39 @@ public class ChaincodeBaseTest {
         environmentVariables.set("CORE_TLS_CLIENT_KEY_PATH", "non_exist_path2");
         environmentVariables.set("CORE_PEER_TLS_ROOTCERT_FILE", "non_exist_path1");
         cb.processEnvironmentOptions();
-        assertEquals("CCId incorrect", cb.getId(), "mycc");
-        assertEquals("Host incorrect", cb.getHost(), "localhost");
-        assertEquals("Port incorrect", cb.getPort(), 7052);
-        assertTrue("TLS should be enabled", cb.isTlsEnabled());
-        assertEquals("Root certificate file", "non_exist_path1", cb.getTlsClientRootCertPath());
-        assertEquals("Client key file", "non_exist_path2", cb.getTlsClientKeyPath());
-        assertEquals("Client certificate file", "non_exist_path3", cb.getTlsClientCertPath());
+        assertThat(cb.getId()).as("CCId incorrect").isEqualTo("mycc");
+        assertThat(cb.getHost()).as("Host incorrect").isEqualTo("localhost");
+        assertThat(cb.getPort()).as("Port incorrect").isEqualTo(7052);
+        assertThat(cb.isTlsEnabled()).as("TLS should be enabled").isTrue();
+        assertThat(cb.getTlsClientRootCertPath()).as("Root certificate file").isEqualTo("non_exist_path1");
+        assertThat(cb.getTlsClientKeyPath()).as("Client key file").isEqualTo("non_exist_path2");
+        assertThat(cb.getTlsClientCertPath()).as("Client certificate file").isEqualTo("non_exist_path3");
 
         environmentVariables.set("CORE_PEER_ADDRESS", "localhost1");
         cb.processEnvironmentOptions();
-        assertEquals("Host incorrect", cb.getHost(), "localhost");
-        assertEquals("Port incorrect", cb.getPort(), 7052);
+        assertThat(cb.getHost()).as("Host incorrect").isEqualTo("localhost");
+        assertThat(cb.getPort()).as("Port incorrect").isEqualTo(7052);
 
-        try {
-            cb.validateOptions();
-        } catch (final IllegalArgumentException e) {
-            fail("Wrong arguments");
-        }
+        assertThatCode(cb::validateOptions).as("Wrong arguments").doesNotThrowAnyException();
 
         cb.processCommandLineOptions(new String[] {"-i", "mycc1", "--peerAddress", "localhost.org:7053"});
-        assertEquals("CCId incorrect", cb.getId(), "mycc1");
-        assertEquals("Host incorrect", cb.getHost(), "localhost.org");
-        assertEquals("Port incorrect", cb.getPort(), 7053);
+        assertThat(cb.getId()).as("CCId incorrect").isEqualTo("mycc1");
+        assertThat(cb.getHost()).as("Host incorrect").isEqualTo("localhost.org");
+        assertThat(cb.getPort()).as("Port incorrect").isEqualTo(7053);
 
-        try {
-            cb.validateOptions();
-        } catch (final IllegalArgumentException e) {
-            fail("Wrong arguments");
-        }
+        assertThatCode(cb::validateOptions).as("Wrong arguments").doesNotThrowAnyException();
 
         cb.processCommandLineOptions(new String[] {"-i", "mycc1", "--peerAddress", "localhost1.org.7054"});
-        assertEquals("Host incorrect", cb.getHost(), "localhost.org");
-        assertEquals("Port incorrect", cb.getPort(), 7053);
+        assertThat(cb.getHost()).as("Host incorrect").isEqualTo("localhost.org");
+        assertThat(cb.getPort()).as("Port incorrect").isEqualTo(7053);
     }
 
     @Test
     public void testUnsetOptionId() {
         final ChaincodeBase cb = new EmptyChaincode();
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(Matchers.containsString("The chaincode id must be specified"));
-        cb.validateOptions();
+        assertThatThrownBy(cb::validateOptions)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The chaincode id must be specified");
     }
 
     @Test
@@ -194,9 +177,9 @@ public class ChaincodeBaseTest {
         environmentVariables.set("CORE_CHAINCODE_ID_NAME", "mycc");
         environmentVariables.set("CORE_PEER_TLS_ENABLED", "true");
         cb.processEnvironmentOptions();
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(Matchers.containsString("Client key certificate chain"));
-        cb.validateOptions();
+        assertThatThrownBy(cb::validateOptions)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Client key certificate chain");
     }
 
     @Test
@@ -206,13 +189,13 @@ public class ChaincodeBaseTest {
         environmentVariables.set("CORE_PEER_TLS_ENABLED", "true");
         environmentVariables.set("CORE_TLS_CLIENT_CERT_PATH", "non_exist_path3");
         cb.processEnvironmentOptions();
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(Matchers.containsString("Client key ("));
-        cb.validateOptions();
+        assertThatThrownBy(cb::validateOptions)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Client key (");
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testNewChannelBuilder() throws Exception {
         final ChaincodeBase cb = new EmptyChaincode();
 
@@ -225,7 +208,7 @@ public class ChaincodeBaseTest {
 
         cb.processEnvironmentOptions();
         cb.validateOptions();
-        assertTrue("Not correct builder", cb.newChannelBuilder() instanceof ManagedChannelBuilder);
+        assertThat(cb.newChannelBuilder()).isInstanceOf(ManagedChannelBuilder.class);
     }
 
     @Test
@@ -234,29 +217,44 @@ public class ChaincodeBaseTest {
 
         cb.processEnvironmentOptions();
         cb.initializeLogging();
-        assertEquals("Wrong log level for org.hyperledger.fabric.shim ", Level.INFO, Logger.getLogger("org.hyperledger.fabric.shim").getLevel());
-        assertEquals("Wrong log level for " + cb.getClass().getPackage().getName(), Level.INFO,
-                Logger.getLogger(cb.getClass().getPackage().getName()).getLevel());
+        assertThat(Logger.getLogger("org.hyperledger.fabric.shim").getLevel())
+                .as("Wrong log level for org.hyperledger.fabric.shim")
+                .isEqualTo(Level.INFO);
+        assertThat(Logger.getLogger(cb.getClass().getPackage().getName()).getLevel())
+                .as("Wrong log level for " + cb.getClass().getPackage().getName())
+                .isEqualTo(Level.INFO);
 
         setLogLevelForChaincode(environmentVariables, cb, "WRONG", "WRONG");
-        assertEquals("Wrong log level for org.hyperledger.fabric.shim ", Level.INFO, Logger.getLogger("org.hyperledger.fabric.shim").getLevel());
-        assertEquals("Wrong log level for " + cb.getClass().getPackage().getName(), Level.INFO,
-                Logger.getLogger(cb.getClass().getPackage().getName()).getLevel());
+        assertThat(Logger.getLogger("org.hyperledger.fabric.shim").getLevel())
+                .as("Wrong log level for org.hyperledger.fabric.shim")
+                .isEqualTo(Level.INFO);
+        assertThat(Logger.getLogger(cb.getClass().getPackage().getName()).getLevel())
+                .as("Wrong log level for " + cb.getClass().getPackage().getName())
+                .isEqualTo(Level.INFO);
 
         setLogLevelForChaincode(environmentVariables, cb, "DEBUG", "NOTICE");
-        assertEquals("Wrong log level for org.hyperledger.fabric.shim ", Level.FINEST, Logger.getLogger("org.hyperledger.fabric.shim").getLevel());
-        assertEquals("Wrong log level for " + cb.getClass().getPackage().getName(), Level.CONFIG,
-                Logger.getLogger(cb.getClass().getPackage().getName()).getLevel());
+        assertThat(Logger.getLogger("org.hyperledger.fabric.shim").getLevel())
+                .as("Wrong log level for org.hyperledger.fabric.shim")
+                .isEqualTo(Level.FINEST);
+        assertThat(Logger.getLogger(cb.getClass().getPackage().getName()).getLevel())
+                .as("Wrong log level for " + cb.getClass().getPackage().getName())
+                .isEqualTo(Level.CONFIG);
 
         setLogLevelForChaincode(environmentVariables, cb, "INFO", "WARNING");
-        assertEquals("Wrong log level for org.hyperledger.fabric.shim ", Level.INFO, Logger.getLogger("org.hyperledger.fabric.shim").getLevel());
-        assertEquals("Wrong log level for " + cb.getClass().getPackage().getName(), Level.WARNING,
-                Logger.getLogger(cb.getClass().getPackage().getName()).getLevel());
+        assertThat(Logger.getLogger("org.hyperledger.fabric.shim").getLevel())
+                .as("Wrong log level for org.hyperledger.fabric.shim")
+                .isEqualTo(Level.INFO);
+        assertThat(Logger.getLogger(cb.getClass().getPackage().getName()).getLevel())
+                .as("Wrong log level for " + cb.getClass().getPackage().getName())
+                .isEqualTo(Level.WARNING);
 
         setLogLevelForChaincode(environmentVariables, cb, "CRITICAL", "ERROR");
-        assertEquals("Wrong log level for org.hyperledger.fabric.shim ", Level.SEVERE, Logger.getLogger("org.hyperledger.fabric.shim").getLevel());
-        assertEquals("Wrong log level for " + cb.getClass().getPackage().getName(), Level.SEVERE,
-                Logger.getLogger(cb.getClass().getPackage().getName()).getLevel());
+        assertThat(Logger.getLogger("org.hyperledger.fabric.shim").getLevel())
+                .as("Wrong log level for org.hyperledger.fabric.shim")
+                .isEqualTo(Level.SEVERE);
+        assertThat(Logger.getLogger(cb.getClass().getPackage().getName()).getLevel())
+                .as("Wrong log level for " + cb.getClass().getPackage().getName())
+                .isEqualTo(Level.SEVERE);
     }
 
     @Test
@@ -274,9 +272,9 @@ public class ChaincodeBaseTest {
         LogRecord lr = argumentCaptor.getValue();
         String msg = lr.getMessage();
 
-        assertThat(msg, not(containsString("java.lang.NullPointerException")));
-        assertThat(msg, containsString(
-            "The chaincode id must be specified using either the -i or --i command line options or the CORE_CHAINCODE_ID_NAME environment variable."));
+        assertThat(msg).doesNotContain("java.lang.NullPointerException");
+        assertThat(msg).contains(
+            "The chaincode id must be specified using either the -i or --i command line options or the CORE_CHAINCODE_ID_NAME environment variable.");
     }
 
     public static void setLogLevelForChaincode(final EnvironmentVariables environmentVariables, final ChaincodeBase cb, final String shimLevel,
@@ -319,7 +317,9 @@ public class ChaincodeBaseTest {
             }
         });
 
-        environmentVariables.clear("CORE_CHAINCODE_ID_NAME", "CORE_PEER_ADDRESS", "CORE_PEER_TLS_ENABLED");
+        environmentVariables.remove("CORE_CHAINCODE_ID_NAME");
+        environmentVariables.remove("CORE_PEER_ADDRESS");
+        environmentVariables.remove("CORE_PEER_TLS_ENABLED");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeServerImplTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeServerImplTest.java
@@ -7,18 +7,21 @@ package org.hyperledger.fabric.shim;
 
 import org.hyperledger.fabric.contract.ContractRouter;
 import org.hyperledger.fabric.shim.chaincode.EmptyChaincode;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+@ExtendWith(SystemStubsExtension.class)
 class ChaincodeServerImplTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @BeforeEach
     void setEnv() {
@@ -33,13 +36,13 @@ class ChaincodeServerImplTest {
 
     @AfterEach
     void clearEnv() {
-        environmentVariables.clear("CORE_CHAINCODE_ID_NAME");
-        environmentVariables.clear("CORE_PEER_ADDRESS");
-        environmentVariables.clear("CORE_PEER_TLS_ENABLED");
-        environmentVariables.clear("CORE_PEER_TLS_ROOTCERT_FILE");
-        environmentVariables.clear("CORE_TLS_CLIENT_KEY_PATH");
-        environmentVariables.clear("CORE_TLS_CLIENT_CERT_PATH");
-        environmentVariables.clear("CHAINCODE_SERVER_ADDRESS");
+        environmentVariables.remove("CORE_CHAINCODE_ID_NAME");
+        environmentVariables.remove("CORE_PEER_ADDRESS");
+        environmentVariables.remove("CORE_PEER_TLS_ENABLED");
+        environmentVariables.remove("CORE_PEER_TLS_ROOTCERT_FILE");
+        environmentVariables.remove("CORE_TLS_CLIENT_KEY_PATH");
+        environmentVariables.remove("CORE_TLS_CLIENT_CERT_PATH");
+        environmentVariables.remove("CHAINCODE_SERVER_ADDRESS");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChaincodeTest.java
@@ -5,54 +5,49 @@
  */
 package org.hyperledger.fabric.shim;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ChaincodeTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testResponse() {
         final Chaincode.Response resp = new Chaincode.Response(Chaincode.Response.Status.SUCCESS, "No message", "no payload".getBytes(StandardCharsets.UTF_8));
-        assertEquals("Incorrect status", Chaincode.Response.Status.SUCCESS, resp.getStatus());
-        assertEquals("Incorrect message", "No message", resp.getMessage());
-        assertEquals("Incorrect payload", "no payload", resp.getStringPayload());
+        assertThat(Chaincode.Response.Status.SUCCESS).as("Incorrect status").isEqualTo(resp.getStatus());
+        assertThat("No message").as("Incorrect message").isEqualTo(resp.getMessage());
+        assertThat("no payload").as("Incorrect payload").isEqualTo(resp.getStringPayload());
     }
 
     @Test
     public void testResponseWithCode() {
         Chaincode.Response resp = new Chaincode.Response(200, "No message", "no payload".getBytes(StandardCharsets.UTF_8));
-        assertEquals("Incorrect status", Chaincode.Response.Status.SUCCESS, resp.getStatus());
-        assertEquals("Incorrect status", 200, resp.getStatusCode());
-        assertEquals("Incorrect message", "No message", resp.getMessage());
-        assertEquals("Incorrect payload", "no payload", resp.getStringPayload());
+        assertThat(Chaincode.Response.Status.SUCCESS).as("Incorrect status").isEqualTo(resp.getStatus());
+        assertThat(200).as("Incorrect status").isEqualTo(resp.getStatusCode());
+        assertThat("No message").as("Incorrect message").isEqualTo(resp.getMessage());
+        assertThat("no payload").as("Incorrect payload").isEqualTo(resp.getStringPayload());
 
         resp = new Chaincode.Response(404, "No message", "no payload".getBytes(StandardCharsets.UTF_8));
-        assertEquals("Incorrect status", 404, resp.getStatusCode());
-        assertEquals("Incorrect message", "No message", resp.getMessage());
-        assertEquals("Incorrect payload", "no payload", resp.getStringPayload());
+        assertThat(404).as("Incorrect status").isEqualTo(resp.getStatusCode());
+        assertThat("No message").as("Incorrect message").isEqualTo(resp.getMessage());
+        assertThat("no payload").as("Incorrect payload").isEqualTo(resp.getStringPayload());
 
         resp = new Chaincode.Response(Chaincode.Response.Status.ERROR_THRESHOLD, "No message", "no payload".getBytes(StandardCharsets.UTF_8));
-        assertEquals("Incorrect status", Chaincode.Response.Status.ERROR_THRESHOLD, resp.getStatus());
-        assertEquals("Incorrect status", 400, resp.getStatusCode());
-        assertEquals("Incorrect message", "No message", resp.getMessage());
-        assertEquals("Incorrect payload", "no payload", resp.getStringPayload());
+        assertThat(Chaincode.Response.Status.ERROR_THRESHOLD).as("Incorrect status").isEqualTo(resp.getStatus());
+        assertThat(400).as("Incorrect status").isEqualTo(resp.getStatusCode());
+        assertThat("No message").as("Incorrect message").isEqualTo(resp.getMessage());
+        assertThat("no payload").as("Incorrect payload").isEqualTo(resp.getStringPayload());
     }
 
     @Test
     public void testStatus() {
-        assertEquals("Wrong status", Chaincode.Response.Status.SUCCESS, Chaincode.Response.Status.forCode(200));
-        assertEquals("Wrong status", Chaincode.Response.Status.ERROR_THRESHOLD, Chaincode.Response.Status.forCode(400));
-        assertEquals("Wrong status", Chaincode.Response.Status.INTERNAL_SERVER_ERROR, Chaincode.Response.Status.forCode(500));
+        assertThat(Chaincode.Response.Status.SUCCESS).as("Wrong status").isEqualTo(Chaincode.Response.Status.forCode(200));
+        assertThat(Chaincode.Response.Status.ERROR_THRESHOLD).as("Wrong status").isEqualTo(Chaincode.Response.Status.forCode(400));
+        assertThat(Chaincode.Response.Status.INTERNAL_SERVER_ERROR).as("Wrong status").isEqualTo(Chaincode.Response.Status.forCode(500));
 
-        thrown.expect(IllegalArgumentException.class);
-        Chaincode.Response.Status.forCode(501);
+        assertThatThrownBy(() -> Chaincode.Response.Status.forCode(501))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChatChaincodeWithPeerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ChatChaincodeWithPeerTest.java
@@ -8,19 +8,21 @@ package org.hyperledger.fabric.shim;
 import com.google.protobuf.ByteString;
 import io.grpc.stub.StreamObserver;
 import org.hyperledger.fabric.metrics.Metrics;
-import org.hyperledger.fabric.protos.peer.ChaincodeSpec;
 import org.hyperledger.fabric.protos.peer.ChaincodeID;
 import org.hyperledger.fabric.protos.peer.ChaincodeInput;
 import org.hyperledger.fabric.protos.peer.ChaincodeMessage;
+import org.hyperledger.fabric.protos.peer.ChaincodeSpec;
 import org.hyperledger.fabric.shim.chaincode.EmptyChaincode;
 import org.hyperledger.fabric.shim.utils.MessageUtil;
 import org.hyperledger.fabric.traces.Traces;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.io.IOException;
 import java.util.List;
@@ -40,10 +42,11 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(SystemStubsExtension.class)
 class ChatChaincodeWithPeerTest {
     private static final String TEST_CHANNEL = "testChannel";
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @BeforeEach
     void setEnv() {
@@ -57,12 +60,12 @@ class ChatChaincodeWithPeerTest {
 
     @AfterEach
     void clearEnv() {
-        environmentVariables.clear("CORE_CHAINCODE_ID_NAME");
-        environmentVariables.clear("CORE_PEER_ADDRESS");
-        environmentVariables.clear("CORE_PEER_TLS_ENABLED");
-        environmentVariables.clear("CORE_PEER_TLS_ROOTCERT_FILE");
-        environmentVariables.clear("CORE_TLS_CLIENT_KEY_PATH");
-        environmentVariables.clear("CORE_TLS_CLIENT_CERT_PATH");
+        environmentVariables.remove("CORE_CHAINCODE_ID_NAME");
+        environmentVariables.remove("CORE_PEER_ADDRESS");
+        environmentVariables.remove("CORE_PEER_TLS_ENABLED");
+        environmentVariables.remove("CORE_PEER_TLS_ROOTCERT_FILE");
+        environmentVariables.remove("CORE_TLS_CLIENT_KEY_PATH");
+        environmentVariables.remove("CORE_TLS_CLIENT_CERT_PATH");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/NettyGrpcServerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/NettyGrpcServerTest.java
@@ -8,20 +8,23 @@ package org.hyperledger.fabric.shim;
 import org.hyperledger.fabric.metrics.Metrics;
 import org.hyperledger.fabric.shim.chaincode.EmptyChaincode;
 import org.hyperledger.fabric.traces.Traces;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Properties;
 
+@ExtendWith(SystemStubsExtension.class)
 class NettyGrpcServerTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @BeforeEach
     void setEnv() {
@@ -36,13 +39,13 @@ class NettyGrpcServerTest {
 
     @AfterEach
     void clearEnv() {
-        environmentVariables.clear("CORE_CHAINCODE_ID_NAME");
-        environmentVariables.clear("CORE_PEER_ADDRESS");
-        environmentVariables.clear("CORE_PEER_TLS_ENABLED");
-        environmentVariables.clear("CORE_PEER_TLS_ROOTCERT_FILE");
-        environmentVariables.clear("CORE_TLS_CLIENT_KEY_PATH");
-        environmentVariables.clear("CORE_TLS_CLIENT_CERT_PATH");
-        environmentVariables.clear("CHAINCODE_SERVER_ADDRESS");
+        environmentVariables.remove("CORE_CHAINCODE_ID_NAME");
+        environmentVariables.remove("CORE_PEER_ADDRESS");
+        environmentVariables.remove("CORE_PEER_TLS_ENABLED");
+        environmentVariables.remove("CORE_PEER_TLS_ROOTCERT_FILE");
+        environmentVariables.remove("CORE_TLS_CLIENT_KEY_PATH");
+        environmentVariables.remove("CORE_TLS_CLIENT_CERT_PATH");
+        environmentVariables.remove("CHAINCODE_SERVER_ADDRESS");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ext/sbe/StateBasedEndorsementTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ext/sbe/StateBasedEndorsementTest.java
@@ -5,23 +5,19 @@
  */
 package org.hyperledger.fabric.shim.ext.sbe;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class StateBasedEndorsementTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testRoleType() {
-        assertEquals("Wrong role", StateBasedEndorsement.RoleType.RoleTypeMember, StateBasedEndorsement.RoleType.forVal("MEMBER"));
-        assertEquals("Wrong role", StateBasedEndorsement.RoleType.RoleTypePeer, StateBasedEndorsement.RoleType.forVal("PEER"));
+        assertThat(StateBasedEndorsement.RoleType.forVal("MEMBER")).isEqualTo(StateBasedEndorsement.RoleType.RoleTypeMember);
+        assertThat(StateBasedEndorsement.RoleType.forVal("PEER")).isEqualTo(StateBasedEndorsement.RoleType.RoleTypePeer);
 
-        thrown.expect(IllegalArgumentException.class);
-        StateBasedEndorsement.RoleType.forVal("NONEXIST");
+        assertThatThrownBy(() -> StateBasedEndorsement.RoleType.forVal("NONEXIST"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ext/sbe/impl/StateBasedEndorsementFactoryTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ext/sbe/impl/StateBasedEndorsementFactoryTest.java
@@ -5,27 +5,24 @@
  */
 package org.hyperledger.fabric.shim.ext.sbe.impl;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 
 public class StateBasedEndorsementFactoryTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void getInstance() {
         assertNotNull(StateBasedEndorsementFactory.getInstance());
-        assertTrue(StateBasedEndorsementFactory.getInstance() instanceof StateBasedEndorsementFactory);
+        assertInstanceOf(StateBasedEndorsementFactory.class, StateBasedEndorsementFactory.getInstance());
     }
 
     @Test
     public void newStateBasedEndorsement() {
         assertNotNull(StateBasedEndorsementFactory.getInstance().newStateBasedEndorsement(new byte[] {}));
-        thrown.expect(IllegalArgumentException.class);
-        StateBasedEndorsementFactory.getInstance().newStateBasedEndorsement(new byte[] {0});
+        assertThatThrownBy(() -> StateBasedEndorsementFactory.getInstance().newStateBasedEndorsement(new byte[] {0}))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ext/sbe/impl/StateBasedEndorsementImplTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ext/sbe/impl/StateBasedEndorsementImplTest.java
@@ -5,21 +5,21 @@
  */
 package org.hyperledger.fabric.shim.ext.sbe.impl;
 
+import org.hyperledger.fabric.protos.common.MSPRole.MSPRoleType;
+import org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement;
+import org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement.RoleType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
-
-import org.hyperledger.fabric.protos.common.MSPRole.MSPRoleType;
-import org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement;
-import org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement.RoleType;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StateBasedEndorsementImplTest {
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/fvt/ChaincodeFVTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/fvt/ChaincodeFVTest.java
@@ -5,27 +5,7 @@
  */
 package org.hyperledger.fabric.shim.fvt;
 
-import static org.hamcrest.Matchers.is;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.COMPLETED;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.INIT;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.READY;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.REGISTER;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.RESPONSE;
-import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.TRANSACTION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.protobuf.ByteString;
-
 import org.hyperledger.fabric.protos.peer.ChaincodeInput;
 import org.hyperledger.fabric.protos.peer.ChaincodeMessage;
 import org.hyperledger.fabric.protos.peer.Response;
@@ -55,19 +35,41 @@ import org.hyperledger.fabric.shim.mock.peer.QueryNextStep;
 import org.hyperledger.fabric.shim.mock.peer.RegisterStep;
 import org.hyperledger.fabric.shim.mock.peer.ScenarioStep;
 import org.hyperledger.fabric.shim.utils.MessageUtil;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.COMPLETED;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.INIT;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.READY;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.REGISTER;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.RESPONSE;
+import static org.hyperledger.fabric.protos.peer.ChaincodeMessage.Type.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ExtendWith(SystemStubsExtension.class)
 public final class ChaincodeFVTest {
 
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     private ChaincodeMockPeer server;
 
-    @After
+    @AfterEach
     public void afterTest() throws Exception {
         if (server != null) {
             server.stop();
@@ -624,9 +626,9 @@ public final class ChaincodeFVTest {
 
         cb.start(new String[] {"-a", "127.0.0.1:7052", "-i", "testId" });
 
-        assertEquals("Wrong debug level for " + cb.getClass().getPackage().getName(), Level.FINEST,
-                Logger.getLogger(cb.getClass().getPackage().getName()).getLevel());
-
+        assertEquals(Level.FINEST,
+                Logger.getLogger(cb.getClass().getPackage().getName()).getLevel(),
+                "Wrong debug level for " + cb.getClass().getPackage().getName());
     }
 
     public void setLogLevel(final String logLevel) {

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/ChaincodeSupportClientTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/ChaincodeSupportClientTest.java
@@ -13,17 +13,21 @@ import org.hyperledger.fabric.protos.peer.ChaincodeMessage;
 import org.hyperledger.fabric.shim.ChaincodeBase;
 import org.hyperledger.fabric.shim.chaincode.EmptyChaincode;
 import org.hyperledger.fabric.traces.Traces;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.io.IOException;
 import java.util.Properties;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(SystemStubsExtension.class)
 class ChaincodeSupportClientTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Test
     void testStartInvocationTaskManagerAndRequestObserverNull() throws IOException {
@@ -39,8 +43,7 @@ class ChaincodeSupportClientTest {
         final ManagedChannelBuilder<?> managedChannelBuilder = chaincodeBase.newChannelBuilder();
         ChaincodeSupportClient chaincodeSupportClient = new ChaincodeSupportClient(managedChannelBuilder);
 
-        Assertions.assertThrows(
-                IOException.class,
+        assertThatThrownBy(
                 () -> {
                     final ChaincodeID chaincodeId = ChaincodeID.newBuilder().setName("chaincodeIdNumber12345").build();
                     final InvocationTaskManager itm = InvocationTaskManager.getManager(chaincodeBase, chaincodeId);
@@ -49,8 +52,8 @@ class ChaincodeSupportClientTest {
                     chaincodeSupportClient.start(itm, requestObserver);
                 },
                 "StreamObserver 'requestObserver' for chat with peer can't be null"
-        );
-        environmentVariables.clear("CORE_CHAINCODE_ID_NAME");
+        ).isInstanceOf(IOException.class);
+        environmentVariables.remove("CORE_CHAINCODE_ID_NAME");
     }
 
     @Test
@@ -67,8 +70,7 @@ class ChaincodeSupportClientTest {
         final ManagedChannelBuilder<?> managedChannelBuilder = chaincodeBase.newChannelBuilder();
         ChaincodeSupportClient chaincodeSupportClient = new ChaincodeSupportClient(managedChannelBuilder);
 
-        Assertions.assertThrows(
-                IOException.class,
+        assertThatThrownBy(
                 () -> {
                     chaincodeSupportClient.start(null, new StreamObserver<ChaincodeMessage>() {
                         @Override
@@ -88,7 +90,7 @@ class ChaincodeSupportClientTest {
                     });
                 },
                 "InvocationTaskManager 'itm' can't be null"
-        );
-        environmentVariables.clear("CORE_CHAINCODE_ID_NAME");
+        ).isInstanceOf(IOException.class);
+        environmentVariables.remove("CORE_CHAINCODE_ID_NAME");
     }
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/InnvocationTaskManagerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/InnvocationTaskManagerTest.java
@@ -13,12 +13,14 @@ import org.hyperledger.fabric.protos.peer.ChaincodeMessage;
 import org.hyperledger.fabric.shim.ChaincodeBase;
 import org.hyperledger.fabric.shim.chaincode.EmptyChaincode;
 import org.hyperledger.fabric.traces.Traces;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -26,9 +28,10 @@ import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(SystemStubsExtension.class)
 class InnvocationTaskManagerTest {
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @SystemStub
+    private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @BeforeEach
     void setEnv() {
@@ -42,12 +45,12 @@ class InnvocationTaskManagerTest {
 
     @AfterEach
     void clearEnv() {
-        environmentVariables.clear("CORE_CHAINCODE_ID_NAME");
-        environmentVariables.clear("CORE_PEER_ADDRESS");
-        environmentVariables.clear("CORE_PEER_TLS_ENABLED");
-        environmentVariables.clear("CORE_PEER_TLS_ROOTCERT_FILE");
-        environmentVariables.clear("CORE_TLS_CLIENT_KEY_PATH");
-        environmentVariables.clear("CORE_TLS_CLIENT_CERT_PATH");
+        environmentVariables.remove("CORE_CHAINCODE_ID_NAME");
+        environmentVariables.remove("CORE_PEER_ADDRESS");
+        environmentVariables.remove("CORE_PEER_TLS_ENABLED");
+        environmentVariables.remove("CORE_PEER_TLS_ROOTCERT_FILE");
+        environmentVariables.remove("CORE_TLS_CLIENT_KEY_PATH");
+        environmentVariables.remove("CORE_TLS_CLIENT_CERT_PATH");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/InvocationTaskManagerTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/InvocationTaskManagerTest.java
@@ -5,14 +5,7 @@
  */
 package org.hyperledger.fabric.shim.impl;
 
-import static org.mockito.Mockito.when;
-
-import java.io.UnsupportedEncodingException;
-import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
-
+import com.google.protobuf.ByteString;
 import org.hyperledger.fabric.metrics.Metrics;
 import org.hyperledger.fabric.protos.peer.ChaincodeID;
 import org.hyperledger.fabric.protos.peer.ChaincodeMessage;
@@ -23,7 +16,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import com.google.protobuf.ByteString;
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.when;
 
 public final class InvocationTaskManagerTest {
 
@@ -65,8 +64,7 @@ public final class InvocationTaskManagerTest {
         final ChaincodeMessage msg = ChaincodeMessageFactory.newEventMessage(ChaincodeMessage.Type.TRANSACTION,
                 "mychannel", "txid", ByteString.copyFrom("Hello", "UTF-8"));
 
-        when(chaincode.getChaincodeConfig()).thenReturn(new Properties());
-        chaincode.setState(ChaincodeBase.CCState.READY);
+        when(chaincode.getState()).thenReturn(ChaincodeBase.CCState.READY);
 
         itm.onChaincodeMessage(msg);
 
@@ -79,8 +77,7 @@ public final class InvocationTaskManagerTest {
         final ChaincodeMessage msg = ChaincodeMessageFactory.newEventMessage(ChaincodeMessage.Type.TRANSACTION,
                 "mychannel", "txid", ByteString.copyFrom("Hello", "UTF-8"));
 
-        when(chaincode.getChaincodeConfig()).thenReturn(new Properties());
-        chaincode.setState(ChaincodeBase.CCState.CREATED);
+        when(chaincode.getState()).thenReturn(ChaincodeBase.CCState.CREATED);
 
         itm.onChaincodeMessage(msg);
 
@@ -92,8 +89,7 @@ public final class InvocationTaskManagerTest {
         final ChaincodeMessage msg = ChaincodeMessageFactory.newEventMessage(ChaincodeMessage.Type.TRANSACTION,
                 "mychannel", "txid", ByteString.copyFrom("Hello", "UTF-8"));
 
-        when(chaincode.getChaincodeConfig()).thenReturn(new Properties());
-        chaincode.setState(ChaincodeBase.CCState.ESTABLISHED);
+        when(chaincode.getState()).thenReturn(ChaincodeBase.CCState.ESTABLISHED);
 
         // final InvocationTaskManager itm =
         // InvocationTaskManager.getManager(chaincode, id);
@@ -107,8 +103,7 @@ public final class InvocationTaskManagerTest {
         final ChaincodeMessage msg = ChaincodeMessageFactory.newEventMessage(ChaincodeMessage.Type.ERROR, "mychannel",
                 "txid", ByteString.copyFrom("Hello", "UTF-8"));
 
-        when(chaincode.getChaincodeConfig()).thenReturn(new Properties());
-        chaincode.setState(ChaincodeBase.CCState.READY);
+        when(chaincode.getState()).thenReturn(ChaincodeBase.CCState.READY);
 
         itm.onChaincodeMessage(msg);
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/KeyModificationImplTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/KeyModificationImplTest.java
@@ -6,23 +6,22 @@
 
 package org.hyperledger.fabric.shim.impl;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import org.hyperledger.fabric.shim.ledger.KeyModification;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.stream.Stream;
 
-import org.hyperledger.fabric.shim.ledger.KeyModification;
-import org.junit.Test;
-
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KeyModificationImplTest {
 
@@ -96,7 +95,7 @@ public class KeyModificationImplTest {
         expectedHashCode = expectedHashCode * 31 + "".hashCode();
         expectedHashCode = expectedHashCode * 31 + ByteString.copyFromUtf8("").hashCode();
 
-        assertEquals("Wrong hash code", expectedHashCode, km.hashCode());
+        assertEquals(expectedHashCode, km.hashCode(), "Wrong hash code");
 
     }
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/KeyValueImplTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/KeyValueImplTest.java
@@ -6,18 +6,17 @@
 
 package org.hyperledger.fabric.shim.impl;
 
+import com.google.protobuf.ByteString;
+import org.hyperledger.fabric.protos.ledger.queryresult.KV;
+import org.junit.jupiter.api.Test;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import org.hyperledger.fabric.protos.ledger.queryresult.KV;
-import org.junit.Test;
-
-import com.google.protobuf.ByteString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class KeyValueImplTest {
 
@@ -65,7 +64,7 @@ public class KeyValueImplTest {
         expectedHashCode = expectedHashCode + "".hashCode();
         expectedHashCode = expectedHashCode * 31 + ByteString.copyFromUtf8("").hashCode();
 
-        assertEquals("Wrong hashcode", expectedHashCode, kv.hashCode());
+        assertEquals(expectedHashCode, kv.hashCode(), "Wrong hashcode");
     }
 
     @Test

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/QueryResultsIteratorWithMetadataImplTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/impl/QueryResultsIteratorWithMetadataImplTest.java
@@ -7,15 +7,15 @@
 package org.hyperledger.fabric.shim.impl;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.function.Function;
 
 import org.hyperledger.fabric.protos.peer.QueryResponse;
 import org.hyperledger.fabric.protos.peer.QueryResultBytes;
 import org.hyperledger.fabric.protos.peer.QueryResponseMetadata;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.ByteString;
 

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ledger/CompositeKeyTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/shim/ledger/CompositeKeyTest.java
@@ -6,15 +6,16 @@
 
 package org.hyperledger.fabric.shim.ledger;
 
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.util.Arrays;
-
-import org.junit.Test;
 
 public class CompositeKeyTest {
     @Test
@@ -22,9 +23,10 @@ public class CompositeKeyTest {
         CompositeKey.validateSimpleKeys("abc", "def", "ghi");
     }
 
-    @Test(expected = CompositeKeyFormatException.class)
-    public void testValidateSimpleKeysException() throws Exception {
-        CompositeKey.validateSimpleKeys("\u0000abc");
+    @Test
+    public void testValidateSimpleKeysException() {
+        assertThatThrownBy(() -> CompositeKey.validateSimpleKeys("\u0000abc"))
+                .isInstanceOf(CompositeKeyFormatException.class);
     }
 
     @Test
@@ -51,24 +53,28 @@ public class CompositeKeyTest {
         assertThat(key.toString(), is(equalTo("\u0000abc\u0000")));
     }
 
-    @Test(expected = CompositeKeyFormatException.class)
+    @Test
     public void testCompositeKeyWithInvalidObjectTypeDelimiter() {
-        new CompositeKey("ab\u0000c", Arrays.asList("def", "ghi", "jkl", "mno"));
+        assertThatThrownBy(() -> new CompositeKey("ab\u0000c", Arrays.asList("def", "ghi", "jkl", "mno")))
+                .isInstanceOf(CompositeKeyFormatException.class);
     }
 
-    @Test(expected = CompositeKeyFormatException.class)
+    @Test
     public void testCompositeKeyWithInvalidAttributeDelimiter() {
-        new CompositeKey("abc", Arrays.asList("def", "ghi", "j\u0000kl", "mno"));
+        assertThatThrownBy(() -> new CompositeKey("abc", Arrays.asList("def", "ghi", "j\u0000kl", "mno")))
+                .isInstanceOf(CompositeKeyFormatException.class);
     }
 
-    @Test(expected = CompositeKeyFormatException.class)
+    @Test
     public void testCompositeKeyWithInvalidObjectTypeMaxCodePoint() {
-        new CompositeKey("ab\udbff\udfffc", Arrays.asList("def", "ghi", "jkl", "mno"));
+        assertThatThrownBy(() -> new CompositeKey("ab\udbff\udfffc", Arrays.asList("def", "ghi", "jkl", "mno")))
+                .isInstanceOf(CompositeKeyFormatException.class);
     }
 
-    @Test(expected = CompositeKeyFormatException.class)
+    @Test
     public void testCompositeKeyWithInvalidAttributeMaxCodePoint() {
-        new CompositeKey("abc", Arrays.asList("def", "ghi", "jk\udbff\udfffl", "mno"));
+        assertThatThrownBy(() -> new CompositeKey("abc", Arrays.asList("def", "ghi", "jk\udbff\udfffl", "mno")))
+                .isInstanceOf(CompositeKeyFormatException.class);
     }
 
     @Test
@@ -100,14 +106,16 @@ public class CompositeKeyTest {
         assertThat(key.toString(), is(equalTo("\u0000abc\u0000def\u0000ghi\u0000jkl\u0000mno\u0000")));
     }
 
-    @Test(expected = CompositeKeyFormatException.class)
+    @Test
     public void testParseCompositeKeyInvalidObjectType() {
-        CompositeKey.parseCompositeKey("ab\udbff\udfffc\u0000def\u0000ghi\u0000jkl\u0000mno\u0000");
+        assertThatThrownBy(() -> CompositeKey.parseCompositeKey("ab\udbff\udfffc\u0000def\u0000ghi\u0000jkl\u0000mno\u0000"))
+                .isInstanceOf(CompositeKeyFormatException.class);
     }
 
-    @Test(expected = CompositeKeyFormatException.class)
+    @Test
     public void testParseCompositeKeyInvalidAttribute() {
-        CompositeKey.parseCompositeKey("abc\u0000def\u0000ghi\u0000jk\udbff\udfffl\u0000mno\u0000");
+        assertThatThrownBy(() -> CompositeKey.parseCompositeKey("abc\u0000def\u0000ghi\u0000jk\udbff\udfffl\u0000mno\u0000"))
+                .isInstanceOf(CompositeKeyFormatException.class);
     }
 
 }

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/traces/impl/OpenTelemetryPropertiesTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/traces/impl/OpenTelemetryPropertiesTest.java
@@ -6,7 +6,7 @@
 package org.hyperledger.fabric.traces.impl;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Also the following dependency changes:

- Remove obsolete JUnit 4.
- Replace `com.github.stefanbirkner:system-rules` with `uk.org.webcompere:system-stubs-jupiter` since the former appears not to work correctly with JUnit 5.