### PR TITLE
Update microfab

### DIFF
--- a/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/util/Peer.java
+++ b/fabric-chaincode-integration-test/src/test/java/org/hyperleder/fabric/shim/integration/util/Peer.java
@@ -150,6 +150,8 @@ public final class Peer extends Command {
                 list.add("--waitForEvent");
             }
 
+            list.add("--orderer");
+            list.add("orderer-api.127-0-0-1.nip.io:8080");
             list.add("--peerAddresses");
             list.add("org1peer-api.127-0-0-1.nip.io:8080");
             list.add("--peerAddresses");

--- a/fabric-chaincode-integration-test/src/test/resources/docker-compose-microfab.yaml
+++ b/fabric-chaincode-integration-test/src/test/resources/docker-compose-microfab.yaml
@@ -9,10 +9,10 @@ services:
 
   microfab:
     container_name: microfab
-    image: ibmcom/ibp-microfab
+    image: ghcr.io/hyperledger-labs/microfab
     tty: true
     environment:
-      - MICROFAB_CONFIG={"couchdb":false,"endorsing_organizations":[{"name":"org1"},{"name":"org2"}],"channels":[{"name":"sachannel","endorsing_organizations":["org1","org2"]}],"capability_level":"V2_0"}
+      - MICROFAB_CONFIG={"couchdb":false,"endorsing_organizations":[{"name":"org1"},{"name":"org2"}],"channels":[{"name":"sachannel","endorsing_organizations":["org1","org2"]}],"capability_level":"V2_5"}
       - FABRIC_LOGGING_SPEC=info
     ports:
       - 8080:8080

--- a/fabric-chaincode-integration-test/src/test/resources/scripts/mfsetup.sh
+++ b/fabric-chaincode-integration-test/src/test/resources/scripts/mfsetup.sh
@@ -11,7 +11,7 @@ mkdir -p "${CFG}"
 # using the IBM tagged version until labs workflow is updated
 docker rm -f microfab || true
 
-export MICROFAB_CONFIG='{"couchdb":false,"endorsing_organizations":[{"name":"org1"},{"name":"org2"}],"channels":[{"name":"sachannel","endorsing_organizations":["org1","org2"]}],"capability_level":"V2_0"}'
+export MICROFAB_CONFIG='{"couchdb":false,"endorsing_organizations":[{"name":"org1"},{"name":"org2"}],"channels":[{"name":"sachannel","endorsing_organizations":["org1","org2"]}],"capability_level":"V2_5"}'
 
 docker run  --name microfab \
             -d \
@@ -20,7 +20,7 @@ docker run  --name microfab \
             --rm \
             -e MICROFAB_CONFIG="${MICROFAB_CONFIG}" \
             -e FABRIC_LOGGING_SPEC=info \
-            ibmcom/ibp-microfab
+            ghcr.io/hyperledger-labs/microfab
 
 
 sleep 10


### PR DESCRIPTION
Update microfab used for integration tests from ibmcom/ibp-microfab to use ghcr.io/hyperledger-labs/microfab. This updates the Fabric runtime for v2.4 to v2.5.