### PR TITLE
Updates to test chaincode to exploit  new microfab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /build/
 build/*
 settings-gradle.lockfile
+config/
 
 _cfg
 repository

--- a/build.gradle
+++ b/build.gradle
@@ -63,14 +63,15 @@ subprojects {
     dependencies {
         implementation 'commons-cli:commons-cli:1.9.0'
         implementation 'commons-logging:commons-logging:1.3.4'
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.0'
+
+        testImplementation platform('org.junit:junit-bom:5.11.3')
+        testImplementation 'org.junit.jupiter:junit-jupiter'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation 'org.assertj:assertj-core:3.26.3'
+        testImplementation 'org.mockito:mockito-core:5.14.2'
+        testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.7'
 
         testImplementation 'org.hamcrest:hamcrest-library:3.0'
-        testImplementation 'org.mockito:mockito-core:5.13.0'
-        testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.6'
-
-        testImplementation 'org.assertj:assertj-core:3.26.3'
     }
 
     test {

--- a/fabric-chaincode-docker/Dockerfile
+++ b/fabric-chaincode-docker/Dockerfile
@@ -1,5 +1,7 @@
-FROM eclipse-temurin:11-jdk as builder
-ENV DEBIAN_FRONTEND=noninteractive 
+ARG JAVA_IMAGE=eclipse-temurin:11-jdk
+
+FROM ${JAVA_IMAGE} as builder
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Build tools
 RUN apt-get update \
@@ -10,10 +12,11 @@ RUN curl -s "https://get.sdkman.io" | bash
 
 SHELL ["/bin/bash", "-c"]
 
-RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install gradle 8.6
-RUN source /root/.sdkman/bin/sdkman-init.sh; sdk install maven 3.9.6
+RUN source /root/.sdkman/bin/sdkman-init.sh \
+    && sdk install gradle 8.11.1 \
+    && sdk install maven 3.9.9
 
-FROM eclipse-temurin:11-jdk as dependencies
+FROM ${JAVA_IMAGE} as dependencies
 
 COPY --from=builder /root/.sdkman/candidates/gradle/current /usr/bin/gradle
 COPY --from=builder /root/.sdkman/candidates/maven/current /usr/bin/maven
@@ -25,12 +28,10 @@ ENV PATH="/usr/bin/maven/bin:/usr/bin/maven/:/usr/bin/gradle:/usr/bin/gradle/bin
 ADD build/distributions/ /root/
 
 #Creating folders structure
-RUN mkdir -p /root/chaincode-java/chaincode/src
-RUN mkdir -p /root/chaincode-java/chaincode/build/out
+RUN mkdir -p /root/chaincode-java/chaincode/src /root/chaincode-java/chaincode/build/out
 
 #Making scripts runnable
-RUN chmod +x /root/chaincode-java/start
-RUN chmod +x /root/chaincode-java/build.sh
+RUN chmod +x /root/chaincode-java/start /root/chaincode-java/build.sh
 
 # Build protos and shim jar and installing them to maven local and gradle cache
 WORKDIR /root/chaincode-java/shim-src
@@ -41,19 +42,21 @@ RUN gradle \
     -x javadoc \
     -x test \
     -x pmdMain \
-    -x pmdTest
+    -x pmdTest \
+    -x spotlessCheck
 
 WORKDIR /root/chaincode-java 
 # Run the Gradle and Maven commands to generate the wrapper variants
 # of each tool
 #Gradle doesn't run without settings.gradle file, so create one
-RUN touch settings.gradle
-RUN gradle wrapper
-RUN mvn -N io.takari:maven:wrapper
+RUN touch settings.gradle \
+    && gradle wrapper \
+    && ./gradlew --version \
+    && mvn -N wrapper:wrapper
 
 # Creating final javaenv image which will include all required
 # dependencies to build and compile java chaincode
-FROM eclipse-temurin:11-jdk
+FROM ${JAVA_IMAGE}
 
 RUN apt-get update \
     && apt-get -y install zip unzip \       
@@ -66,6 +69,7 @@ SHELL ["/bin/bash", "-c"]
 
 # Copy setup scripts, and the cached dependencies
 COPY --from=dependencies /root/chaincode-java /root/chaincode-java
+COPY --from=dependencies /root/.gradle /root/.gradle
 COPY --from=dependencies /root/.m2 /root/.m2
 
 WORKDIR /root/chaincode-java

--- a/fabric-chaincode-integration-test/.gitignore
+++ b/fabric-chaincode-integration-test/.gitignore
@@ -1,3 +1,4 @@
 repository
 _cfg
 *.tar.gz
+log.txt

--- a/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/bare-gradle/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'com.gradleup.shadow' version '8.3.5'
     id 'java'
 }
 
@@ -29,9 +29,9 @@ dependencies {
 }
 
 shadowJar {
-    baseName = 'chaincode'
-    version = null
-    classifier = null
+    archiveBaseName = 'chaincode'
+    archiveVersion = ''
+    archiveClassifier = ''
     mergeServiceFiles()
 
     manifest {

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.5'
     id 'java'
 }
 
 group 'org.hyperledger.fabric-chaincode-java'
-version '1.0-SNAPSHOT'
+version ''
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/gradle/wrapper/gradle-wrapper.properties
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-ledger-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.5'
     id 'java'
 }
 

--- a/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/gradle/wrapper/gradle-wrapper.properties
+++ b/fabric-chaincode-integration-test/src/contracts/fabric-shim-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -42,13 +42,13 @@ tasks.withType(org.gradle.api.tasks.testing.Test) {
 
 dependencies {
     implementation platform('com.google.protobuf:protobuf-bom:3.25.5')
-    implementation platform('io.grpc:grpc-bom:1.68.0')
+    implementation platform('io.grpc:grpc-bom:1.68.1')
     implementation platform('io.opentelemetry:opentelemetry-bom:1.42.1')
 
     implementation 'org.hyperledger.fabric:fabric-protos:0.3.3'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
-    implementation 'io.github.classgraph:classgraph:4.8.176'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.79'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.79'
+    implementation 'io.github.classgraph:classgraph:4.8.179'
     implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.4'
     implementation 'org.json:json:20240303'
     implementation 'com.google.protobuf:protobuf-java-util'
@@ -86,7 +86,7 @@ sourceSets {
 }
 
 jacoco {
-    toolVersion = "0.8.6"
+    toolVersion = "0.8.12"
 }
 
 jacocoTestReport {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
New microfab version provides an up-to-date Gradle version, which the test chaincode can be updated to exploit.

This change also updates several dependencies to current versions.

This change required hyperledger-labs/microfab#174. The version of Gradle contained in microfab v0.0.19 is too old to support current versions of the Gradle shadowJar used in this change for the bare Gradle chaincode tests.