### PR TITLE
Use Java 21 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Push to registry ${{ matrix.publish_target }}
         run: |
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Build the dependencies needed for the image
         run: ./gradlew :fabric-chaincode-docker:copyAllDeps

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 21
     - uses: gradle/actions/setup-gradle@v4
     - name: Build and Unit test
       run: ./gradlew :fabric-chaincode-shim:build 
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Populate chaincode with latest java-version
         run: |
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Build Docker image
         run: ./gradlew :fabric-chaincode-docker:buildImage

--- a/fabric-chaincode-docker/Dockerfile
+++ b/fabric-chaincode-docker/Dockerfile
@@ -1,6 +1,6 @@
-ARG JAVA_IMAGE=eclipse-temurin:11-jdk
+ARG JAVA_IMAGE=eclipse-temurin:21-jdk
 
-FROM ${JAVA_IMAGE} as builder
+FROM ${JAVA_IMAGE} AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Build tools
@@ -16,7 +16,7 @@ RUN source /root/.sdkman/bin/sdkman-init.sh \
     && sdk install gradle 8.11.1 \
     && sdk install maven 3.9.9
 
-FROM ${JAVA_IMAGE} as dependencies
+FROM ${JAVA_IMAGE} AS dependencies
 
 COPY --from=builder /root/.sdkman/candidates/gradle/current /usr/bin/gradle
 COPY --from=builder /root/.sdkman/candidates/maven/current /usr/bin/maven

--- a/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/ContractDefinitionTest.java
+++ b/fabric-chaincode-shim/src/test/java/org/hyperledger/fabric/contract/routing/ContractDefinitionTest.java
@@ -5,69 +5,23 @@
  */
 package org.hyperledger.fabric.contract.routing;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
 
 import contract.SampleContract;
 import java.lang.reflect.Method;
-import java.security.Permission;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.ContractInterface;
 import org.hyperledger.fabric.contract.ContractRuntimeException;
-import org.hyperledger.fabric.contract.annotation.Contract;
-import org.hyperledger.fabric.contract.annotation.Info;
 import org.hyperledger.fabric.contract.routing.impl.ContractDefinitionImpl;
 import org.junit.jupiter.api.Test;
 
 final class ContractDefinitionTest {
     @Test
-    void constructor() throws NoSuchMethodException, SecurityException {
+    void constructor() throws SecurityException {
 
         final ContractDefinition cf = new ContractDefinitionImpl(SampleContract.class);
-        assertThat(cf.toString(), startsWith("samplecontract:"));
-    }
-
-    @Contract(name = "", info = @Info())
-    public class FailureTestObject {}
-
-    private boolean fail;
-    private static final int STEP = 1;
-
-    @Test
-    void unknownRoute() {
-
-        final SecurityManager tmp = new SecurityManager() {
-            private int count = 0;
-
-            @Override
-            public void checkPackageAccess(final String pkg) {
-
-                if (pkg.startsWith("org.hyperledger.fabric.contract")) {
-                    if (count >= STEP) {
-                        throw new SecurityException("Sorry I can't do that");
-                    }
-                    count++;
-                }
-                super.checkPackageAccess(pkg);
-            }
-
-            @Override
-            public void checkPermission(final Permission perm) {}
-        };
-
-        try {
-            final ContractDefinition cf = new ContractDefinitionImpl(SampleContract.class);
-            System.setSecurityManager(tmp);
-            this.fail = true;
-
-            cf.getUnknownRoute();
-        } catch (final Exception e) {
-            assertThat(e.getMessage(), equalTo("Failure to find unknownTransaction method"));
-        } finally {
-            System.setSecurityManager(null);
-        }
+        assertThat(cf.toString()).startsWith("samplecontract:");
     }
 
     @Test


### PR DESCRIPTION
Using Java 21 as the runtime allows chaincode developers to exploit newer Java features, and provides JVM performance improvements. Java 11 is no longer supported by RedHat and public support from other vendors ends in 2027.

This change removes a test for a security manager failure since the security manager is deprecated and its use is disallowed by Java 21.

Chaincode must now use Gradle wrappers at version 8.5 or later, since that version of Gradle added support for execution using Java 21.