### PR TITLE
Use native runners to build Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
   workflow_dispatch:
 
-jobs:
-  test:
-    uses: ./.github/workflows/test.yml
+env:
+  IMAGE_NAME: ${{ github.repository_owner }}/fabric-javaenv
 
+jobs:
   # Publishing steps to both the Github Packages and the Sonatype
   publishjars:
     strategy:
@@ -24,7 +24,6 @@ jobs:
           - publishAllPublicationsToGithubPackagesRepository
           - publishAllPublicationsToReleaseRepository
     runs-on: ubuntu-latest
-    needs: test
     permissions:
       contents: read
       packages: write
@@ -32,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Push to registry ${{ matrix.publish_target }}
@@ -47,67 +46,107 @@ jobs:
           TARGET: ${{ matrix.publish_target }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Publish to Docker registries: docker.io and ghcr.io
-  publishdocker:
-    runs-on: ubuntu-latest
-    needs: test
+  docker-build-push:
+    name: Push Docker image
+    runs-on: ${{ matrix.arch.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - platform: linux-amd64
+            runner: ubuntu-24.04
+          - platform: linux-arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Build the dependencies needed for the image
         run: ./gradlew :fabric-chaincode-docker:copyAllDeps
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
-          buildkitd-config-inline: |
-            [worker.oci]
-              max-parallelism = 1
-      - name: Login to Docker Hub
-        # If testing on a fork, login error may occur and can be ignored
-        continue-on-error: true
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Get commit timestamp
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker meta
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          file: fabric-chaincode-docker/Dockerfile
+          context: fabric-chaincode-docker
+          outputs: type=registry,"name=${{ format('ghcr.io/{0},docker.io/{0}', env.IMAGE_NAME) }}",push-by-digest=true,name-canonical=true
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch.platform }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+
+  docker-meta:
+    needs: docker-build-push
+    name: Publish Docker metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        registry:
+          - docker.io
+          - ghcr.io
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+      - name: Login to ${{ matrix.registry }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ matrix.registry }}
+          username: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # If testing on a fork, Docker Hub publish might fail so place it last
-          images: |
-            ghcr.io/${{ github.repository_owner }}/fabric-javaenv
-            docker.io/${{ github.repository_owner }}/fabric-javaenv
+          images: ${{ matrix.registry }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
-      - name: Get Git commit timestamps
-        run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
-      - name: Build and push image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          file: fabric-chaincode-docker/Dockerfile
-          context: fabric-chaincode-docker
-          tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.meta.outputs.labels }}
-        env:
-          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("--tag " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}") \
+            $(printf '${{ matrix.registry }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Inspect image
+        run: docker buildx imagetools inspect '${{ matrix.registry }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       ref:
-        default: ''
+        default: ""
         required: false
         type: string
 
@@ -16,16 +16,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.ref }}
-    - uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 21
-    - uses: gradle/actions/setup-gradle@v4
-    - name: Build and Unit test
-      run: ./gradlew :fabric-chaincode-shim:build 
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build and Unit test
+        run: ./gradlew :fabric-chaincode-shim:build
 
   intergationtest:
     runs-on: ubuntu-latest
@@ -37,6 +37,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
       - uses: gradle/actions/setup-gradle@v4
       - name: Populate chaincode with latest java-version
         run: |
@@ -49,7 +52,7 @@ jobs:
         run: |
           curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/install-fabric.sh | bash -s -- binary
           npm install -g @hyperledger-labs/weft
-          
+
           # set the path and cfg env var for the rest of the step
           echo "FABRIC_CFG_PATH=$GITHUB_WORKSPACE/config" >> $GITHUB_ENV
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,9 +3,9 @@
 The following artifacts are created as a result of releasing Fabric Chaincode Java:
 
 - docker images
-    - [fabric-javaenv](https://hub.docker.com/r/hyperledger/fabric-javaenv)
+  - [fabric-javaenv](https://hub.docker.com/r/hyperledger/fabric-javaenv)
 - Java libraries
-    - [fabric-chaincode-shim](https://search.maven.org/search?q=a:fabric-chaincode-shim)
+  - [fabric-chaincode-shim](https://search.maven.org/search?q=a:fabric-chaincode-shim)
 
 **Note:** A docker image with a matching V.R version is required before releasing a new version of Fabric.
 
@@ -17,9 +17,11 @@ The following tasks are required before releasing:
 
 - Update version numbers in `build.gradle` files to the required version
 - Update test, sample, and docs files to match the new version
-- Update the [`COMPATIBILITY.md`](./COMPATIBILITY.md) 
+- Update the [`COMPATIBILITY.md`](./COMPATIBILITY.md)
 
 See the [[FABCJ-289] release: 2.2.0 LTS](https://github.com/hyperledger/fabric-chaincode-java/pull/124) pull request for an example, although be careful to search for all versions in the codebase as they're easy to miss and things change!
+
+Ensure the last branch build passed since exactly this repository state will be released.
 
 ## Create release
 
@@ -57,6 +59,7 @@ See the [Bump version to 2.2.1](https://github.com/hyperledger/fabric-chaincode-
 ## Interim Build Publishing
 
 The nightly Azure Pipeline Builds will also publish the 'dev' drivers to Artifactory. These can be accessed via the repository at
+
 ```
     maven {
         url "https://hyperledger.jfrog.io/hyperledger/fabric-maven"


### PR DESCRIPTION
Instead of relying on QEMU emulation to build multi-arch images, use native arm64 and amd64 build runners to build architecture-specific images, then publish multi-arch metadata with each of the image manifests.