### PR TITLE
Use OSV-Scanner v2

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,10 +24,5 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          cache: false
       - name: Scan
         run: make scan

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-.PHONEY: scan
-scan:
-	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-	./gradlew --quiet resolveAndLockAll --write-locks
-	osv-scanner scan --lockfile=fabric-chaincode-shim/gradle.lockfile
+bin_dir := bin
+osv-scanner := $(bin_dir)/osv-scanner
+
+kernel_name := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+machine_hardware := $(shell uname -m)
+ifeq ($(machine_hardware), x86_64)
+	machine_hardware := amd64
+endif
+ifeq ($(machine_hardware), aarch64)
+	machine_hardware := arm64
+endif
+
+.PHONY: scan
+scan: $(osv-scanner)
+	./gradlew --quiet :fabric-chaincode-shim:dependencies --write-locks --configuration runtimeClasspath
+	bin/osv-scanner scan --lockfile=fabric-chaincode-shim/gradle.lockfile
+
+.PHONY: install-osv-scanner
+install-osv-scanner:
+	mkdir -p '$(bin_dir)'
+	curl --fail --location --show-error --silent --output '$(osv-scanner)' \
+    		'https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_$(kernel_name)_$(machine_hardware)'
+	chmod u+x '$(osv-scanner)'
+
+$(osv-scanner):
+	$(MAKE) install-osv-scanner

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -26,16 +26,6 @@ configurations {
     }
 }
 
-tasks.register('resolveAndLockAll') {
-    notCompatibleWithConfigurationCache("Filters configurations at execution time")
-    doFirst {
-        assert gradle.startParameter.writeDependencyLocks : "$path must be run from the command line with the `--write-locks` flag"
-    }
-    doLast {
-        configurations.findAll { it.canBeResolved }.each { it.resolve() }
-    }
-}
-
 tasks.withType(org.gradle.api.tasks.testing.Test) {
     systemProperty 'CORE_CHAINCODE_LOGGING_LEVEL', 'DEBUG'
 }


### PR DESCRIPTION
Update the vulnerability scan of dependencies to use OSV-Scanner v2. Also rework the Makefile targets so that a precompiled OSV-Scanner binary is downloaded and avoid the need for Go to be installed.