### PR TITLE
Setup Go for vulnerability scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+      - uses: actions/setup-go@v5 # Needed for scanning of v2.5.5 and earlier
+        with:
+          go-version: stable
+          cache: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin


### PR DESCRIPTION
Go is still needed to run the vulnerability scan successfully on v2.5.5 and earlier.