### PR TITLE
update commons-lang to 3.18

### DIFF
--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -32,6 +32,11 @@ tasks.withType(org.gradle.api.tasks.testing.Test) {
 }
 
 dependencies {
+    constraints {
+        pmd('org.apache.commons:commons-lang3:3.18.0') {
+            because('CVE-2025-48924')
+        }
+    }
     implementation platform('com.google.protobuf:protobuf-bom:4.31.1')
     implementation platform('io.grpc:grpc-bom:1.73.0')
     implementation platform('io.opentelemetry:opentelemetry-bom:1.51.0')


### PR DESCRIPTION
A moderate-severity vulnerability was reported in commons-lang, a transitive dependency of pmd. Since the latest version of pmd does not yet include a patch, a pull request has been created as a temporary fix.

Reference: https://github.com/advisories/GHSA-j288-q9x7-2f5v