### PR TITLE
Allow scanning of all dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,16 @@ endif
 
 .PHONY: scan
 scan: $(osv-scanner)
+	rm -f fabric-chaincode-shim/gradle.lockfile
 	./gradlew --quiet :fabric-chaincode-shim:dependencies --write-locks --configuration runtimeClasspath
 	bin/osv-scanner scan --lockfile=fabric-chaincode-shim/gradle.lockfile
+
+.PHONY: scan-all
+scan-all: $(osv-scanner)
+	rm -f fabric-chaincode-shim/gradle.lockfile
+	./gradlew --quiet :fabric-chaincode-shim:dependencies --write-locks
+	bin/osv-scanner scan --lockfile=fabric-chaincode-shim/gradle.lockfile
+
 
 .PHONY: install-osv-scanner
 install-osv-scanner:

--- a/fabric-chaincode-shim/build.gradle
+++ b/fabric-chaincode-shim/build.gradle
@@ -21,10 +21,8 @@ pmd {
 
 pmdTest.enabled = false
 
-configurations {
-    runtimeClasspath {
-        resolutionStrategy.activateDependencyLocking()
-    }
+dependencyLocking {
+    lockAllConfigurations()
 }
 
 tasks.withType(org.gradle.api.tasks.testing.Test) {


### PR DESCRIPTION
The default vulnerability scan, run with `make scan`, checks only the runtimeClasspath dependencies. This change add a `scan-all` Makefile target that checks all dependencies, including test and plugin dependencies.