### PR TITLE
Update Junit from 5.13.4 to 6.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,22 +46,16 @@ subprojects {
     group = 'org.hyperledger.fabric-chaincode-java'
     version = rootProject.version
 
-    java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
     compileJava {
-        if (javaCompiler.get().metadata.languageVersion.canCompileOrRun(10)) {
-            options.release = 11
-        }
+        options.release = 11
+        options.compilerArgs += ['-Werror', '-Xlint:all']
     }
 
     dependencies {
         implementation 'commons-cli:commons-cli:1.10.0'
         implementation 'commons-logging:commons-logging:1.3.5'
 
-        testImplementation platform('org.junit:junit-bom:5.13.4')
+        testImplementation platform('org.junit:junit-bom:6.0.0')
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testImplementation 'org.assertj:assertj-core:3.27.6'

--- a/examples/fabric-contract-example-as-service/build.gradle
+++ b/examples/fabric-contract-example-as-service/build.gradle
@@ -15,7 +15,8 @@ repositories {
 dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.7'
     implementation 'org.json:json:20250517'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testImplementation platform('org.junit:junit-bom:6.0.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.27.6'
     testImplementation 'org.mockito:mockito-core:5.20.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/examples/fabric-contract-example-gradle/build.gradle
+++ b/examples/fabric-contract-example-gradle/build.gradle
@@ -15,9 +15,11 @@ repositories {
 dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.7'
     implementation 'org.json:json:20250517'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testImplementation platform('org.junit:junit-bom:6.0.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.27.6'
     testImplementation 'org.mockito:mockito-core:5.20.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 shadowJar {

--- a/examples/fabric-contract-example-maven/pom.xml
+++ b/examples/fabric-contract-example-maven/pom.xml
@@ -18,10 +18,6 @@
 		<logback.version>1.5.19</logback.version>
 		<slf4j.version>2.0.17</slf4j.version>
 
-		<!-- Test -->
-		<junit.jupiter.version>5.13.4</junit.jupiter.version>
-		<junit.platform.version>1.13.1</junit.platform.version>
-
 	</properties>
 	
     <repositories>
@@ -31,7 +27,19 @@
         </repository>
     </repositories>
 
-	<dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>6.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
 
 		<!-- fabric-chaincode-java -->
 		<dependency>
@@ -69,19 +77,16 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>${junit.jupiter.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
 <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
@@ -102,7 +107,6 @@
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
-					<!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.5.4</version>

--- a/examples/ledger-api/build.gradle
+++ b/examples/ledger-api/build.gradle
@@ -15,9 +15,11 @@ repositories {
 dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.7'
     implementation 'org.json:json:20250517'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testImplementation platform('org.junit:junit-bom:6.0.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.27.6'
     testImplementation 'org.mockito:mockito-core:5.20.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 shadowJar {

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/Logger.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/Logger.java
@@ -14,11 +14,15 @@ import java.util.logging.LogManager;
 /** Logger class to use throughout the Contract Implementation. */
 public class Logger extends java.util.logging.Logger {
 
+    /**
+     * Subclasses must ensure that a parent logger is set appropriately, for example:
+     *
+     * <p>{@code logger.setParent(java.util.logging.Logger.getLogger("org.hyperledger.fabric"))}
+     *
+     * @param name A name for the logger.
+     */
     protected Logger(final String name) {
         super(name, null);
-
-        // ensure that the parent logger is set
-        super.setParent(java.util.logging.Logger.getLogger("org.hyperledger.fabric"));
     }
 
     /**
@@ -26,7 +30,9 @@ public class Logger extends java.util.logging.Logger {
      * @return Logger
      */
     public static Logger getLogger(final String name) {
-        return new Logger(name);
+        Logger result = new Logger(name);
+        result.setParent(java.util.logging.Logger.getLogger("org.hyperledger.fabric"));
+        return result;
     }
 
     /** @param msgSupplier */

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/QueryResultsIteratorImpl.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/impl/QueryResultsIteratorImpl.java
@@ -107,7 +107,7 @@ class QueryResultsIteratorImpl<T> implements QueryResultsIterator<T> {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
 
         final ByteString requestPayload = QueryStateClose.newBuilder()
                 .setId(currentQueryResponse.getId())

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ledger/QueryResultsIterator.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ledger/QueryResultsIterator.java
@@ -12,4 +12,7 @@ package org.hyperledger.fabric.shim.ledger;
  *
  * @param <T> the type of elements returned by the iterator
  */
-public interface QueryResultsIterator<T> extends Iterable<T>, AutoCloseable {}
+public interface QueryResultsIterator<T> extends Iterable<T>, AutoCloseable {
+    @Override
+    void close();
+}

--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ledger/QueryResultsIteratorWithMetadata.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ledger/QueryResultsIteratorWithMetadata.java
@@ -18,4 +18,7 @@ import org.hyperledger.fabric.protos.peer.QueryResponseMetadata;
 public interface QueryResultsIteratorWithMetadata<T> extends Iterable<T>, AutoCloseable {
     /** @return Query Metadata */
     QueryResponseMetadata getMetadata();
+
+    @Override
+    void close();
 }


### PR DESCRIPTION
Requires a minimum of Java 17 for compilation. The release target remains Java 11.

This change also enabled Java compiler linting and fails on linting errors. To address lint failures in the existing codebase, the bahviour of the org.hyperledger.fabric.Logger constructor has changed to avoid a potential 'this' escape. Any subclasses must now ensure that the parent logger is set explicitly after construction by calling setParent(Logger). No changes are required for code obtaining logger instances using the static Logger.getLogger(String) method.