### PR TITLE
ChaincodeBase: fix 'occured' -> 'occurred' in error log messages

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeBase.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/ChaincodeBase.java
@@ -202,7 +202,7 @@ public abstract class ChaincodeBase implements Chaincode {
                     @Override
                     public void onError(final Throwable t) {
                         LOGGER.severe(
-                                () -> "An error occured on the chaincode stream. Shutting down the chaincode stream."
+                                () -> "An error occurred on the chaincode stream. Shutting down the chaincode stream."
                                         + Logging.formatError(t));
 
                         chaincodeSupportClient.shutdown(itm);
@@ -257,7 +257,7 @@ public abstract class ChaincodeBase implements Chaincode {
 
             @Override
             public void onError(final Throwable t) {
-                LOGGER.severe(() -> "An error occured on the chaincode stream. Shutting down the chaincode stream."
+                LOGGER.severe(() -> "An error occurred on the chaincode stream. Shutting down the chaincode stream."
                         + Logging.formatError(t));
 
                 chaincodeSupportClient.shutdown(itm);


### PR DESCRIPTION
Two log messages in `ChaincodeBase.java` (lines 205, 260) read `An error occured on the chaincode stream`. Fixed to `occurred`. String-literal-only change.