### PR TITLE
Exclude TLS key password from chaincode server log

### DIFF
--- a/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/NettyGrpcServer.java
+++ b/fabric-chaincode-shim/src/main/java/org/hyperledger/fabric/shim/NettyGrpcServer.java
@@ -70,7 +70,6 @@ public final class NettyGrpcServer implements GrpcServer {
             LOGGER.info("PermitKeepAliveTimeMinutes:" + chaincodeServerProperties.getPermitKeepAliveTimeMinutes());
             LOGGER.info("KeepAliveTimeMinutes:" + chaincodeServerProperties.getKeepAliveTimeMinutes());
             LOGGER.info("PermitKeepAliveWithoutCalls:" + chaincodeServerProperties.getPermitKeepAliveWithoutCalls());
-            LOGGER.info("KeyPassword:" + chaincodeServerProperties.getKeyPassword());
             LOGGER.info("KeyCertChainFile:" + chaincodeServerProperties.getKeyCertChainFile());
             LOGGER.info("KeyFile:" + chaincodeServerProperties.getKeyFile());
             LOGGER.info("isTlsEnabled:" + chaincodeServerProperties.isTlsEnabled());


### PR DESCRIPTION
The constructor for the NettyGrpcServer implementation included an info level log of all of the chaincode server properties, including the TLS key password. While both the key and accompanying password are necessary to allow the chaincode server to be impersonated, an attacker with access to the chaincode server filesystem where the key is stored would likely also have access to the logs containing the key password. The password is sensitive information that should not be logged regardless.